### PR TITLE
Fix markdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,8 +2,9 @@
 name: Bug report
 about: Create a report to help us improve
 title: "[BUG] - TYPE BRIEF DESCRIPTION HERE"
-labels: ""
-assignees: ""
+labels: ''
+assignees: ''
+
 ---
 
 **Describe the bug**
@@ -11,7 +12,6 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
-
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -24,17 +24,15 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Setup:**
-
-- Foundry Version: [e.g. 9.238]
-- System Version: [e.g. DND5e 1.5.7]
-- Sequencer Version: [e.g. 1.0.0]
-- Browser & version [e.g. Google Chrome 98.0.4758.82]
+ - Foundry Version: [e.g. 9.238]
+ - System Version: [e.g. DND5e 1.5.7]
+ - Sequencer Version: [e.g. 1.0.0]
+ - Browser & version [e.g. Google Chrome 98.0.4758.82]
 
 **Active modules:**
-
-- Sequencer
-- socketlib
-- [insert more modules here]
+ - Sequencer
+ - socketlib
+ - [insert more modules here]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,8 +2,9 @@
 name: Feature request
 about: Suggest an idea for this project
 title: "[REQUEST] - TYPE SHORT DESCRIPTION HERE"
-labels: ""
-assignees: ""
+labels: ''
+assignees: ''
+
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+.vite-cache/**
+**/*.md

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 A module made by [Fantasy Computerworks](http://fantasycomputer.works/).
 
 Other works by us:
-
 - [Fantasy Calendar](https://app.fantasy-calendar.com) - The best calendar creator and management app on the internet
 - [Item Piles](https://foundryvtt.com/packages/item-piles) - Drag & drop items into the scene to drop item piles that you can then easily pick up
 - [Tagger](https://foundryvtt.com/packages/tagger) - Tag objects in the scene and retrieve them with a powerful API
@@ -31,10 +30,9 @@ Sequencer is a powerful module that lets you play visual effects in your scenes,
 ## The new wiki can be found at [https://fantasycomputer.works/FoundryVTT-Sequencer/](https://fantasycomputer.works/FoundryVTT-Sequencer/)
 
 ## Effects shown on this wiki
-
-- [JB2A - Jules&Ben's Animated Assets](https://foundryvtt.com/packages/JB2A_DnD5e) (Full paid version [here](https://www.patreon.com/JB2A))
-- [Jack Kerouac's Animated Spell Effects](https://foundryvtt.com/packages/animated-spell-effects)
-- [Jack Kerouac's Animated Cartoon Spell Effets](https://foundryvtt.com/packages/animated-spell-effects-cartoon)
+* [JB2A - Jules&Ben's Animated Assets](https://foundryvtt.com/packages/JB2A_DnD5e) (Full paid version [here](https://www.patreon.com/JB2A))
+* [Jack Kerouac's Animated Spell Effects](https://foundryvtt.com/packages/animated-spell-effects)
+* [Jack Kerouac's Animated Cartoon Spell Effets](https://foundryvtt.com/packages/animated-spell-effects-cartoon)
 
 ## Installation
 
@@ -48,17 +46,14 @@ If you want to test the beta track, you can install it from this link - **NOT RE
 ## [Changelog](docs/changelog.md)
 
 ## Credits
-
 ### Feedback and amazing help
-
-- U-man over at [FXMaster](https://gitlab.com/mesfoliesludiques/foundryvtt-fxmaster) for his implementation of layers - Copyright © 2020 Emmanuel Ruaud
-- Otigon with his [Automated Animations](https://github.com/otigon/automated-jb2a-animations) for his work on handling standardized effects - Copyright © 2020 Otigon
-- ghost (ghost#2000 on discord) for his fixes to the audio sections
-- Kandashi (Kandashi#6698 on discord) for the inspiration and code of persistent effects
-- Naito (Naito#1235 on discord) for his assistance with improving the Database Viewer's speed
-- League of Extraordinary FoundryVTT Developers for their ongoing support and suggestions
-- Foundry VTT Core code for heaps of inspiration
+* U-man over at [FXMaster](https://gitlab.com/mesfoliesludiques/foundryvtt-fxmaster) for his implementation of layers - Copyright © 2020 Emmanuel Ruaud
+* Otigon with his [Automated Animations](https://github.com/otigon/automated-jb2a-animations) for his work on handling standardized effects - Copyright © 2020 Otigon
+* ghost (ghost#2000 on discord) for his fixes to the audio sections
+* Kandashi (Kandashi#6698 on discord) for the inspiration and code of persistent effects
+* Naito (Naito#1235 on discord) for his assistance with improving the Database Viewer's speed
+* League of Extraordinary FoundryVTT Developers for their ongoing support and suggestions
+* Foundry VTT Core code for heaps of inspiration
 
 ### Other Attributions
-
 - [Easing Functions Cheat Sheet](https://easings.net/) ([GitHub](https://github.com/ai/easings.net)) - Copyright © 2020 Andrey Sitnik and Ivan Solovev

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,10 +5,9 @@
 Sequencer is a powerful module that lets you play visual effects in your scenes, attaching them to tokens or other elements, animating them, quickly and easily removing them, play sounds for all or specific players, run macros one after another in a controlled way, and so much more.
 
 ## Effects shown on this wiki
-
-- [JB2A - Jules&Ben's Animated Assets](https://foundryvtt.com/packages/JB2A_DnD5e) (Full paid version [here](https://www.patreon.com/JB2A))
-- [Jack Kerouac's Animated Spell Effects](https://foundryvtt.com/packages/animated-spell-effects)
-- [Jack Kerouac's Animated Cartoon Spell Effets](https://foundryvtt.com/packages/animated-spell-effects-cartoon)
+* [JB2A - Jules&Ben's Animated Assets](https://foundryvtt.com/packages/JB2A_DnD5e) (Full paid version [here](https://www.patreon.com/JB2A))
+* [Jack Kerouac's Animated Spell Effects](https://foundryvtt.com/packages/animated-spell-effects)
+* [Jack Kerouac's Animated Cartoon Spell Effets](https://foundryvtt.com/packages/animated-spell-effects-cartoon)
 
 ## Installation
 
@@ -22,17 +21,14 @@ If you want to test the beta track, you can install it from this link - **NOT RE
 ## [Changelog](changelog.md)
 
 ## Credits
-
 ### Feedback and amazing help
-
-- U-man over at [FXMaster](https://gitlab.com/mesfoliesludiques/foundryvtt-fxmaster) for his implementation of layers - Copyright © 2020 Emmanuel Ruaud
-- Otigon with his [Automated Animations](https://github.com/otigon/automated-jb2a-animations) for his work on handling standardized effects - Copyright © 2020 Otigon
-- ghost (ghost#2000 on discord) for his fixes to the audio sections
-- Kandashi (Kandashi#6698 on discord) for the inspiration and code of persistent effects
-- Naito (Naito#1235 on discord) for his assistance with improving the Database Viewer's speed
-- League of Extraordinary FoundryVTT Developers for their ongoing support and suggestions
-- Foundry VTT Core code for heaps of inspiration
+* U-man over at [FXMaster](https://gitlab.com/mesfoliesludiques/foundryvtt-fxmaster) for his implementation of layers - Copyright © 2020 Emmanuel Ruaud
+* Otigon with his [Automated Animations](https://github.com/otigon/automated-jb2a-animations) for his work on handling standardized effects - Copyright © 2020 Otigon
+* ghost (ghost#2000 on discord) for his fixes to the audio sections
+* Kandashi (Kandashi#6698 on discord) for the inspiration and code of persistent effects
+* Naito (Naito#1235 on discord) for his assistance with improving the Database Viewer's speed
+* League of Extraordinary FoundryVTT Developers for their ongoing support and suggestions
+* Foundry VTT Core code for heaps of inspiration
 
 ### Other Attributions
-
 - [Easing Functions Cheat Sheet](https://easings.net/) ([GitHub](https://github.com/ai/easings.net)) - Copyright © 2020 Andrey Sitnik and Ivan Solovev

--- a/docs/api/animation.md
+++ b/docs/api/animation.md
@@ -7,14 +7,13 @@ This part of the Sequencer acts **on** objects in the scene, such as tokens, til
 ### How do I use this?
 
 When creating an animation section, you can assemble these methods like this:
-
 ```js
 new Sequence()
-  .animation()
-  .on(token)
-  .fadeIn(500)
-  .teleportTo({ x: 100, y: 0 })
-  .play();
+    .animation()
+        .on(token)
+        .fadeIn(500)
+        .teleportTo({ x: 100, y: 0 })
+    .play()
 ```
 
 <hr/>
@@ -56,7 +55,6 @@ It is highly recommended that you do not load too many files at the same time, a
 Causes the section not play, and skip all delays, repetitions, waits, etc. If you pass a function, the function should return something false-y if you do not want the effect or sound to play.
 
 Below is an example of a function used in this method, which would cause this effect or sound to only be played about 50% of the time.
-
 ```js
 .playIf(() => {
 	return Math.random() < 0.5;
@@ -270,7 +268,6 @@ Check out what easings are available here: https://easings.net/
 `.tint()` or `.tint(hexadecimal)` or `.tint(decimal)`
 
 Examples:
-
 - `.tint("#FF0000")` - Red tint
 - `.tint(0x0000FF)` - Blue tint
 
@@ -287,3 +284,5 @@ Causes the animated object to be hidden (or visible, if the parameter passed to 
 `.show()` or `.show(boolean)`
 
 Causes the animated object to be visible (or hidden, if the parameter passed to it is `false`)
+
+

--- a/docs/api/effect.md
+++ b/docs/api/effect.md
@@ -7,28 +7,23 @@ This part of the Sequencer allows you to easily play visual effects on the canva
 ### How do I use this?
 
 When creating an effect section, you can assemble these methods like this:
-
 ```js
 new Sequence()
-  .effect()
-  .atLocation(token)
-  .file(
-    "modules/jb2a_patreon/Library/Generic/Healing/HealingAbility_01_Blue_200x200.webm"
-  )
-  .fadeIn(500)
-  .fadeOut(500)
-  .play();
+    .effect()
+        .atLocation(token)
+        .file("modules/jb2a_patreon/Library/Generic/Healing/HealingAbility_01_Blue_200x200.webm")
+        .fadeIn(500)
+        .fadeOut(500)
+    .play()
 ```
-
 or an effect that uses a [Sequencer Database](https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/How-to:-Sequencer-Database) path:
-
 ```js
 new Sequence()
-  .effect()
-  .atLocation(token)
-  .stretchTo(target)
-  .file("jb2a.fire_bolt.orange")
-  .play();
+    .effect()
+        .atLocation(token)
+        .stretchTo(target)
+        .file("jb2a.fire_bolt.orange")
+    .play()
 ```
 
 <hr/>
@@ -70,7 +65,6 @@ It is highly recommended that you do not load too many files at the same time, a
 Causes the effect not play, and skip all delays, repetitions, waits, etc. If you pass a function, the function should return something false-y if you do not want the effect or sound to play.
 
 Below is an example of a function used in this method, which would cause this effect or sound to only be played about 50% of the time.
-
 ```js
 .playIf(() => {
     return Math.random() < 0.5;
@@ -222,7 +216,6 @@ If there are multiple files in the database with `.xxft` in their database paths
 We recommend users and creators alike read the documentation on the [Sequencer database](https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/Sequencer-Database).
 
 Lastly, you may pass a range-finding type object to the file method:
-
 ```js
 .file({
     "05ft": "modules/jb2a_patreon/Library/1st_Level/Witch_Bolt/WitchBolt_01_Regular_Blue_05ft_600x400.webm",
@@ -240,7 +233,6 @@ Sequencer will pick the best file to play for the given distance between the sou
 `.from(token|tile, object)`
 
 Examples:
-
 ```js
 .from(token)
 .from(tile)
@@ -251,7 +243,6 @@ Examples:
 Create an effect based on the given object, effectively copying the object as an effect. Useful when you want to do some effect magic on tokens or tiles. When used with a token or a tile, the effect will be placed at the exact same place as the object.
 
 Also supports a second options object that accepts:
-
 - `cacheLocation: boolean` - causes the given object's location to be cached immediately rather than retrieved during the Sequence's runtime
 - `randomOffset: number|boolean` - causes the location to be offset by a random amount - if given a number, this acts as a multiplier for the randomness, using the size of the object (or a single grid square/hex) as the multiplier.
 - `offset: object` (default `{ x: 0, y: 0 }`) - causes the location to be offset by a set amount
@@ -263,7 +254,6 @@ Also supports a second options object that accepts:
 `.atLocation(object|string, object)`
 
 Examples:
-
 ```js
 .atLocation(token)
 .atLocation("stored_name")
@@ -273,14 +263,12 @@ Examples:
 ```
 
 A smart method that can take:
-
 - Reference to a token
 - Reference to a template
 - Direct coordinate on the canvas
 - String reference (see [`.name()`](#name))
 
 Also supports a second options object that accepts:
-
 - `cacheLocation: boolean` - causes the given object's location to be cached immediately rather than retrieved during the Sequence's runtime
 - `randomOffset: number|boolean` - causes the location to be offset by a random amount - if given a number, this acts as a multiplier for the randomness, using the size of the object (or a single grid square/hex) as the multiplier.
 - `offset: object` (default `{ x: 0, y: 0 }`) - causes the location to be offset by a set amount
@@ -292,7 +280,6 @@ Also supports a second options object that accepts:
 `.attachTo(object|string, object)`
 
 Examples:
-
 ```js
 .attachTo(token)
 .attachTo(template)
@@ -304,7 +291,6 @@ Examples:
 This method makes the effect attached to an object. If the object cannot have attached effects, the effect will be created on the canvas.
 
 A smart method that can take:
-
 - Reference to a placeable object (tokens, templates, lights, etc)
 - String reference (see [`.name()`](#name))
 
@@ -327,7 +313,6 @@ In addition, a secondary options parameter can be given to this method, which ha
 `.rotateTowards(object|string, object)`
 
 Examples:
-
 ```js
 .rotateTowards(token)
 .rotateTowards("stored_name")
@@ -339,7 +324,6 @@ Examples:
 Causes the effect to be rotated towards the given token, template, coordinates, or a string reference (see [`.name()`](#name)). This is useful if you want to play an effect on a token facing another token, like an explosion or a magical effect.
 
 Also supports a second options object that accepts:
-
 - `cacheLocation: boolean` (default `false`) - causes the given object's location to be cached immediately rather than retrieved during the Sequence's runtime
 - `attachTo: boolean` (default `false`) - causes the effect to be attached to the target (combine with [`.attachTo()`](#attachTo) for two-way bindings!)
 - `randomOffset: number|boolean` - causes the location to be offset by a random amount - if given a number, this acts as a multiplier for the randomness, using the size of the object (or a single grid square/hex) as the multiplier.
@@ -353,7 +337,6 @@ Also supports a second options object that accepts:
 `.stretchTo(object|string, object)`
 
 Examples:
-
 ```js
 .stretchTo(token)
 .stretchTo("stored_name")
@@ -365,7 +348,6 @@ Examples:
 Causes the effect to be rotated and stretched towards the given token, template, coordinates, or a string reference (see [`.name()`](#name)). This effectively calculates the proper X scale for the effect to stretch to the target.
 
 Also supports a second options object that accepts:
-
 - `cacheLocation: boolean` (default `false`) - causes the given object's location to be cached immediately rather than retrieved during the Sequence's runtime
 - `attachTo: boolean` (default `false`) - causes the effect to be attached to the target (combine with [`.attachTo()`](#attachTo) for two-way bindings!)
 - `onlyX: boolean` (default `false`) - causes the effect to only stretch the X axis of the sprite towards the target (keeping Y at 1.0, or your given scale)
@@ -380,7 +362,6 @@ Also supports a second options object that accepts:
 `.moveTowards(object, object)`
 
 Examples:
-
 ```js
 .moveTowards(token)
 .moveTowards("stored_name")
@@ -391,7 +372,6 @@ Examples:
 Causes the effect to move towards the given token, template, coordinates, or a string reference (see [`.name()`](#name)).
 
 Also supports a second options object that accepts:
-
 - `ease: string` (default `linear`) - set the ease of the movement,
 - `cacheLocation: boolean` (default `false`) - causes the given object's location to be cached immediately rather than retrieved during the Sequence's runtime
 - `rotate: boolean` (default `true`) - causes the effect to rotate towards the target
@@ -415,7 +395,6 @@ Causes the effect's location (or target location, if using `.stretchTo()` or `.m
 `.spriteOffset(inOffset, options)`
 
 Examples:
-
 ```js
 .spriteOffset({ x: 100, y: -50 })
 .spriteOffset({ x: 1 }, { gridUnits: true })
@@ -424,7 +403,6 @@ Examples:
 This causes the effect's **sprite** to be offset relative to its container based on a given vector. Sprite Offset is independent from `.atLocation()` and other location's `offset` parameter.
 
 A second options parameter accepts the following properties:
-
 - `gridUnits` - boolean (false) - Whether the given values in x and y should be treated as the number of grids
 - `local: boolean` - Used with `offset` to cause the location to be offset locally to the effect's rotation
 - `gridUnits: boolean` - Used with `offset` to make each whole number represent in `x` and `y` to represent the effect's scene's grid size
@@ -442,7 +420,6 @@ Causes the effect to not rotate should its container (see `spriteContainer` in [
 Calling this method will cause the effect to become permanent on the canvas. You can end the effect with the [Effect Manager](https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/Sequencer-Effect-Manager).
 
 Also supports a second options object that accepts:
-
 - `persistTokenPrototype: boolean` (default `false`) - makes the effect persist on the token's prototype data, useful for active effect-linked VFX
 
 ## Extra End Duration
@@ -469,7 +446,7 @@ Used for adding extra information to an effect, like the origin of the effect in
 
 `.name(inString)`
 
-Causes the effect's position to be stored and can then be used with [`.atLocation()`](#at-location), [`.stretchTo()`](#stretch-to), [`.rotateTowards()`](#rotate-towards), and [`.moveTowards()`](#move-towards) to refer to previous effects' locations
+Causes the effect's position to be stored and can then be used  with [`.atLocation()`](#at-location), [`.stretchTo()`](#stretch-to), [`.rotateTowards()`](#rotate-towards), and [`.moveTowards()`](#move-towards) to refer to previous effects' locations
 
 ## Private
 
@@ -494,9 +471,9 @@ If a location has been picked with [`.atLocation()`](#at-location), a random spo
 })
 ```
 
-- `effect` is a reference to the effect in itself - interact with this at your own risk.
+* `effect` is a reference to the effect in itself - interact with this at your own risk.
 
-- `data` is the effect's data that is going to be passed to canvas layer.
+* `data` is the effect's data that is going to be passed to canvas layer.
 
 Adds a function that will run at the end of the effect serialization step, but before it is played. Allows direct modifications of effect's data.
 
@@ -509,7 +486,6 @@ You _must_ define the function like above and return the data at the end of the 
 Sets the width and the height of the effect in pixels, this size is set before any scaling.
 
 A secondary options object may be passed to the method, which may contain:
-
 - `gridUnits: boolean` (default `false`) - Causes the numbers given to the width and height to be counted as grid units, rather than pixel dimensions
 
 ## Template
@@ -559,19 +535,17 @@ You can also pass functions that will get evaluated during runtime by Mustache:
 ```
 
 This would result in a random color, and a random number between 1 and 9, so any of these:
-
-- `MagicMissile_01_Regular_Blue_30ft_01_1600x400.webm`
-- `MagicMissile_01_Regular_Green_30ft_08_1600x400.webm`
-- `MagicMissile_01_Regular_Yellow_30ft_02_1600x400.webm`
-- `MagicMissile_01_Regular_Purple_30ft_04_1600x400.webm`
-- ...and so on
+* `MagicMissile_01_Regular_Blue_30ft_01_1600x400.webm`
+* `MagicMissile_01_Regular_Green_30ft_08_1600x400.webm`
+* `MagicMissile_01_Regular_Yellow_30ft_02_1600x400.webm`
+* `MagicMissile_01_Regular_Purple_30ft_04_1600x400.webm`
+* ...and so on
 
 ## Scale
 
 `.scale(0.5)` or `.scale({ x: 0.5, y: 1.0 })` or `.scale(0.2, 0.6)`
 
 A method that can take the following:
-
 - A number to set the scale uniformly
 - An object with x and y for non-uniform scaling
 - Two numbers which the Sequencer will randomly pick a uniform scale between
@@ -625,7 +599,6 @@ Causes the effect to be scaled to the target object's grid dimensions - for exam
 A number be passed to the method, causing the effect to also scale uniformly (1.5 meaning 150% of the target object's dimensions).
 
 A secondary options parameter can be passed as well, which accepts the following parameters:
-
 - `uniform: boolean` (default `false`) - This causes the scaling to always be uniform, as it picks the largest dimension of the object
 
 ## Sprite Scale
@@ -633,7 +606,6 @@ A secondary options parameter can be passed as well, which accepts the following
 `.spriteScale(0.5)` or `.spriteScale({ x: 0.5, y: 1.0 })` or `.spriteScale(0.2, 0.6)`
 
 A method that scales the sprite directly (independently from `.scale()`) that take the following:
-
 - A number to set the scale uniformly
 - An object with x and y for non-uniform scaling
 - Two numbers which the Sequencer will randomly pick a uniform scale between
@@ -693,29 +665,26 @@ const source = canvas.tokens.controlled[0];
 const target = Array.from(game.user.targets)[0];
 
 // Find effects on source with name "arrow"
-const currentEffects = Sequencer.EffectManager.getEffects({
-  source: source,
-  name: "arrow",
-});
+const currentEffects = Sequencer.EffectManager.getEffects({ source: source, name: "arrow" }) 
 
 // If none were found
-if (currentEffects.length != 0) {
-  // End effects on source named "arrow"
-  Sequencer.EffectManager.endEffects({ source: source, name: "arrow" });
-} else {
-  new Sequence()
-    .effect()
-    .file("jb2a.ui.indicator.green.01.01") // Play arrow animation from Sequencer Database
-    .attachTo(source, { followRotation: false }) // Attach to source token but do not rotate with it
-    .rotateTowards(target, { attachTo: true }) // Rotate towards target token
-    .scaleToObject(0.75) // Scale effect to fit token's size
-    .persist() // Make it last forever
-    .spriteOffset({ x: 0.5 }, { gridUnits: true }) // Move above token by 1 grid unit
-    .spriteRotation(90) // Rotate the sprite itself 90 degrees
-    .name("arrow") // Name it arrow so that the effect manager can find it
-    .fadeIn(500) // When first created, fade it in
-    .fadeOut(500) // When ending, fade it out
-    .play();
+if( currentEffects.length != 0 ) {
+    // End effects on source named "arrow"
+    Sequencer.EffectManager.endEffects({ source: source, name: "arrow" });
+}else{
+    new Sequence()
+        .effect()
+            .file("jb2a.ui.indicator.green.01.01")          // Play arrow animation from Sequencer Database
+            .attachTo(source, { followRotation: false })    // Attach to source token but do not rotate with it
+            .rotateTowards(target, { attachTo: true })      // Rotate towards target token
+            .scaleToObject(0.75)                            // Scale effect to fit token's size
+            .persist()                                      // Make it last forever
+            .spriteOffset({ x: 0.5 }, { gridUnits: true })  // Move above token by 1 grid unit
+            .spriteRotation(90)                             // Rotate the sprite itself 90 degrees
+            .name("arrow")                                  // Name it arrow so that the effect manager can find it
+            .fadeIn(500)                                    // When first created, fade it in
+            .fadeOut(500)                                   // When ending, fade it out
+        .play()
 }
 ```
 
@@ -806,7 +775,6 @@ Sets the z-index of the effect, potentially displaying it on top of or below oth
 `.animateProperty(target, propertyName, options)`
 
 Examples:
-
 - `.animateProperty("sprite", "position.x", { from: -200, to: 200, duration: 500})`
 - `.animateProperty("sprite", "rotation", { from: 0, to: 360, duration: 1500, ease: "easeInOutCubic"})`
 - `.animateProperty("spriteContainer", "rotation", { from: 0, to: 180, duration: 5000, delay: 500 })`
@@ -818,9 +786,7 @@ Animates a property on the target of the animation.
 Valid targets are `sprite` (the effect itself) and `spriteContainer` (the effect's container).
 
 Animatable properties are as follows:
-
 - `sprite`
-
   - `position.x`
   - `position.y`
   - `rotation` (degrees)
@@ -831,7 +797,6 @@ Animatable properties are as follows:
   - `height`
 
 - `alphaFilter`
-
   - `alpha`
 
 - `spriteContainer`
@@ -857,7 +822,6 @@ Check out what easings are available here: https://easings.net/
 `.loopProperty(target, propertyName, options)`
 
 Examples:
-
 - `.loopProperty("sprite", "position.x", { from: -200, to: 200, duration: 500})`
 - `.loopProperty("sprite", "rotation", { from: 0, to: 360, duration: 1500})`
 - `.loopProperty("spriteContainer", "rotation", { from: 0, to: 180, duration: 5000, delay: 500 })`
@@ -874,9 +838,7 @@ If no `options.loops` are provided, the animation is indefinite (lasts forever).
 Valid targets are `sprite` (the effect itself) and `spriteContainer` (the effect's container).
 
 Animatable properties are as follows:
-
 - `sprite`
-
   - `position.x`
   - `position.y`
   - `rotation` (degrees)
@@ -887,7 +849,6 @@ Animatable properties are as follows:
   - `height`
 
 - `alphaFilter`
-
   - `alpha`
 
 - `spriteContainer`
@@ -899,7 +860,6 @@ Animatable properties are as follows:
   - `scale.y`
 
 Default parameters:
-
 ```js
 {
     loops: 0,
@@ -919,7 +879,6 @@ Check out what easings are available here: https://easings.net/
 `.filter(string, object)`
 
 Examples:
-
 - `.filter("ColorMatrix", { hue: 100 })`
 - `.filter("Glow", { color: 0xFF0000 })`
 - `.filter("Blur", { blurX: 5, blurY: 10 })`
@@ -933,7 +892,6 @@ You may "stack" multiple filters on top of each other, and they will work in con
 `.tint()` or `.tint(hexadecimal)` or `.tint(decimal)`
 
 Examples:
-
 - `.tint("#FF0000")` - Red tint
 - `.tint(0x0000FF)` - Blue tint
 
@@ -950,6 +908,7 @@ Causes the effect to be played in screen space instead of world space (where tok
 `.screenSpaceAboveUI()` or `.screenSpaceAboveUI(boolean)`
 
 If `.screenSpace()` has been used, this will cause the effect to be played above all elements in Foundry.
+
 
 ## Screen Space Position
 
@@ -986,13 +945,17 @@ Sets up various properties relating to scale of the effect on the screen. Accept
 
 ```js
 const style = {
-  fill: "red",
-  fontFamily: "Arial Black",
-  fontSize: 28,
-  strokeThickness: 4,
-};
+    "fill": "red",
+    "fontFamily": "Arial Black",
+    "fontSize": 28,
+    "strokeThickness": 4
+}
 
-new Sequence().effect().atLocation(token).text("Test Text", style).play();
+new Sequence()
+   .effect()
+      .atLocation(token)
+      .text("Test Text", style)
+   .play()
 ```
 
 Creates a text element, attached to the effect. The options for the text are available here:
@@ -1001,43 +964,31 @@ Creates a text element, attached to the effect. The options for the text are ava
 
 Use the JSON object as the options parameter for `.text()`
 
+
 ## Shape
 
 `.shape(inType, inOptions)`
 
 ```js
 new Sequence()
-  .effect()
-  .attachTo(token)
-  .persist()
-  .shape("circle", {
-    lineSize: 4,
-    lineColor: "#FF0000",
-    radius: 1.5,
-    gridUnits: true,
-    name: "test",
-  })
-  .loopProperty("shapes.test", "scale.x", {
-    from: 0.9,
-    to: 1.1,
-    duration: 1000,
-    pingPong: true,
-    ease: "easeInOutSine",
-  })
-  .loopProperty("shapes.test", "scale.y", {
-    from: 0.9,
-    to: 1.1,
-    duration: 1000,
-    pingPong: true,
-    ease: "easeInOutSine",
-  })
-  .play();
+    .effect()
+        .attachTo(token)
+        .persist()
+        .shape("circle", {
+            lineSize: 4,
+            lineColor: "#FF0000",
+            radius: 1.5,
+            gridUnits: true,
+            name: "test"
+        })
+        .loopProperty("shapes.test", "scale.x", { from: 0.9, to: 1.1, duration: 1000, pingPong: true, ease: "easeInOutSine" })
+        .loopProperty("shapes.test", "scale.y", { from: 0.9, to: 1.1, duration: 1000, pingPong: true, ease: "easeInOutSine" })
+    .play()
 ```
 
 Creates a graphics element, attached to the effect.
 
 The supported shapes (`inType`) are:
-
 - "polygon"
 - "rectangle"
 - "circle"
@@ -1045,14 +996,13 @@ The supported shapes (`inType`) are:
 - "roundedRect"
 
 The optional options are as follows:
-
 - `radius`: `number` - The radius of `circle` shapes, and the radius of the `roundedRect` edges
 - `width`: `number` - The width of `rectangle`, `ellipse`, and `roundedRect` shapes
 - `height`: `number` - The height of `rectangle`, `ellipse`, and `roundedRect` shapes
-- `points`: `Array<[number, number]|{ x: number, y: number}>` - The points of a `polygon` object
+- `points`: `Array<[number, number]|{ x: number, y: number}>` - The points of a `polygon` object 
 - `gridUnits`: `boolean` - Whether the positions or height/width should be considered grid units (1 = one grid on the canvas grid)
 - `name`: `string` - What name to give this shape, which can be used with `.animateProperty()` and `.loopProperty()` through `shapes.[name]`
-- `fillColor`: `string|number` - The fill color of the shape, must be decimal (`0xFF0000`) or hexadecimal (`"#FF000000"`)
+- `fillColor`: `string|number` - The fill color of the shape, must be decimal (`0xFF0000`) or hexadecimal (`"#FF000000"`)  
 - `fillAlpha`: `number` - The alpha of the fill color
 - `alpha`: `number` - The alpha of the entire shape
 - `lineSize`: `number` - The size of the outline of the shape (in pixels)
@@ -1071,6 +1021,7 @@ Causes the effect to ignore vision-based masking.
 `.mask()` or `.mask(token)` or `.mask([list, of, objects])`
 
 Masks the effect to the given object or objects. If no object is given, the effect will be masked to the source of the effect.
+
 
 ## Tie To Documents
 

--- a/docs/api/filter.md
+++ b/docs/api/filter.md
@@ -7,7 +7,6 @@
 `.filter("ColorMatrix", inData)`
 
 `inData` may contain any of the following:
-
 ```js
 {
     hue: 0,          // Number, in degrees
@@ -22,7 +21,6 @@
 `.filter("Glow", inData)`
 
 `inData` may contain any of the following:
-
 ```js
 {
     distance: 10,      // Number, distance of the glow in pixels
@@ -38,7 +36,6 @@
 
 `.filter("Blur", inData)`
 `inData` may contain any of the following:
-
 ```js
 {
     strength: 8,    // Number, strength of the filter

--- a/docs/api/home.md
+++ b/docs/api/home.md
@@ -3,29 +3,24 @@
 ## Creating A New Sequence
 
 You can start a new Sequence by simply calling:
-
-```js
-new Sequence();
-```
-
-Any other methods you call on this will continue to work on the same sequence, like so:
-
 ```js
 new Sequence()
-  .thenDo(function () {
-    console.log("I'm in here.");
-  })
-  .thenDo(function () {
-    console.log("But now, I'm in here!");
-  });
+```
+Any other methods you call on this will continue to work on the same sequence, like so:
+```js
+new Sequence()
+     .thenDo(function(){
+          console.log("I'm in here.")
+     })
+     .thenDo(function(){
+          console.log("But now, I'm in here!")
+     })
 ```
 
 For module developers, by putting your module name in the Sequence like this:
-
 ```js
-new Sequence({ moduleName: "myModuleName" });
+new Sequence({ moduleName: "myModuleName" })
 ```
-
 Means that any errors will show up like this:
 
 ![Sequencer module error example](../images/error-example.jpg)
@@ -35,10 +30,10 @@ This will help you and your module's users to get to the bottom of the issue.
 In addition, you can also add `softFail` like so:
 
 ```js
-new Sequence({ moduleName: "myModuleName", softFail: true });
+new Sequence({ moduleName: "myModuleName", softFail: true })
 ```
 
-This will make sequencer consider all failures to find an effect file, sound file, or a macro a non-issue and simply continues executing the sequence, rather than halt the execution.
+This will make sequencer consider all failures to find an effect file, sound file, or a macro a non-issue and simply continues executing the sequence, rather than halt the execution. 
 
 ## Core Methods
 
@@ -65,12 +60,6 @@ Creates a sound section. Until you call any of the [core methods](#sequencer-cor
 `.scrollingText()` or `.scrollingText(inToken, inText, inTextStyles)`
 
 Creates a scrolling text section. Until you call any of the [core methods](#sequencer-core-methods), you'll be working on the scrolling text section.
-
-### Canvas Pan
-
-`.canvasPan()` or `.canvasPan(inTarget, inDuration, inScale)`
-
-Creates a canvas pan section. Until you call any of the [core methods](#sequencer-core-methods), you'll be working on the canvas pan section.
 
 ### Then do
 
@@ -117,24 +106,6 @@ Adds the sections from a given Sequence to this Sequence. This is useful if you 
 Returns `Promise`
 
 Causes the Sequence to play through all of its sections. Returns a `Promise` which resolves when all sections have played.
-
-You can pass an object to this method, which can contain `remote` as a boolean, like `{ remote: true }`. This will serialize the sequence, and send it to each client for local playback, instead of the person running the sequence sending data to clients as it is being executed.
-
-### To JSON
-
-`.toJSON()`
-
-Returns `object`.
-
-Calling this will serialize the sequence, which can be saved and reused with `.fromJSON()` (see below.) **Note:** Only sequences with effects, sounds, scrolling texts, and canvas pans can be serialized.
-
-### From JSON
-
-`.fromJSON(inObject)`
-
-Returns `Sequence`
-
-This will take a serialized sequence and reconstruct it, which can then be `.play()`ed.
 
 ### Preset
 

--- a/docs/api/scrolling-text.md
+++ b/docs/api/scrolling-text.md
@@ -7,26 +7,25 @@ This part of the Sequencer allows you to easily display scrolling text on the ca
 ### How do I use this?
 
 When creating a scrolling text section, you can assemble these methods like this:
-
-```js
-new Sequence().scrollingText(token, "My Text").play();
-```
-
-or more involved
-
 ```js
 new Sequence()
-  .scrollingText()
-  .atLocation(token, { randomOffset: true })
-  .text("My text", {
-    fill: "#ffffff",
-    fontSize: 35,
-    fontWeight: "bold",
-    lineJoin: "round",
-    strokeThickness: 3,
-  })
-  .duration(1000)
-  .play();
+    .scrollingText(token, "My Text")
+    .play()
+```
+or more involved
+```js
+new Sequence()
+    .scrollingText()
+        .atLocation(token, { randomOffset: true })
+        .text("My text", {
+          "fill": "#ffffff",
+          "fontSize": 35,
+          "fontWeight": "bold",
+          "lineJoin": "round",
+          "strokeThickness": 3
+        })
+        .duration(1000)
+    .play()
 ```
 
 <hr/>
@@ -37,7 +36,7 @@ new Sequence()
 
 Calling this method will cause the scrolling text to finish running before starting the next section.
 
-Passing a number as a parameter will cause the scrolling text to wait for the given number (in ms) after finishing playing before continuing to the next section.
+Passing a number as a parameter will cause the scrolling text or sound to wait for the given number (in ms) after finishing playing before continuing to the next section.
 
 If given a negative number, the Sequencer will continue to the next section early but continue playing the scrolling text.
 
@@ -63,10 +62,9 @@ As an option, you can give it `inRepeatDelayMin` for a static delay between repe
 
 `.playIf(boolean)` or `.playIf(inFunction)`
 
-Causes the scrolling text not to play, and skip all delays, repetitions, waits, etc. If you pass a function, the function should return something false-y if you do not want the scrolling text or sound to play.
+Causes the scrolling text not play, and skip all delays, repetitions, waits, etc. If you pass a function, the function should return something false-y if you do not want the scrolling text or sound to play.
 
 Below is an example of a function used in this method, which would cause this scrolling text to only be played about 50% of the time.
-
 ```js
 .playIf(() => {
     return Math.random() < 0.5;
@@ -104,7 +102,6 @@ Accepts a single user ID or username (case-sensitive), or an array thereof.
 `.atLocation(object|string, object)`
 
 Examples:
-
 ```js
 .atLocation(token)
 .atLocation({ x: 0, y: 0 })
@@ -113,13 +110,11 @@ Examples:
 ```
 
 A smart method that can take:
-
 - Reference to a token
 - Reference to a template
 - Direct coordinate on the canvas
 
 Also supports a second options object that accepts:
-
 - `cacheLocation: boolean` - causes the given object's location to be cached immediately rather than retrieved during the Sequence's runtime
 - `randomOffset: number|boolean` - causes the location to be offset by a random amount - if given a number, this acts as a multiplier for the randomness, using the size of the object (or a single grid square/hex) as the multiplier.
 - `offset: object` (default `{ x: 0, y: 0 }`) - causes the location to be offset by a set amount
@@ -131,13 +126,17 @@ Also supports a second options object that accepts:
 
 ```js
 const style = {
-  fill: "red",
-  fontFamily: "Arial Black",
-  fontSize: 28,
-  strokeThickness: 4,
-};
+    "fill": "red",
+    "fontFamily": "Arial Black",
+    "fontSize": 28,
+    "strokeThickness": 4
+}
 
-new Sequence().scrollingText().atLocation(token).text("My Text", style).play();
+new Sequence()
+   .scrollingText()
+      .atLocation(token)
+      .text("My Text", style)
+   .play()
 ```
 
 Sets the text and styling of the scrolling text.
@@ -145,6 +144,7 @@ Sets the text and styling of the scrolling text.
 <a>https://pixijs.io/pixi-text-style/</a>
 
 Use the JSON object as the options parameter for `.text()`
+
 
 ## Anchor
 
@@ -154,6 +154,7 @@ Sets the placement of the text's location on the location.
 
 You can either set this with Foundry's native `CONST.TEXT_ANCHOR_POINTS`, or by giving it any of `CENTER`, `BOTTOM`, `TOP`, `LEFT`, or `RIGHT`.
 
+
 ## Direction
 
 `.direction(string|number)`
@@ -162,7 +163,8 @@ Sets the direction the text's movement.
 
 You can either set this with Foundry's native `CONST.TEXT_ANCHOR_POINTS`, or by giving it any of `CENTER`, `BOTTOM`, `TOP`, `LEFT`, or `RIGHT`.
 
-## Jitter
+
+## jitter
 
 `.jitter(number)`
 

--- a/docs/api/sound.md
+++ b/docs/api/sound.md
@@ -1,18 +1,16 @@
 ### What is this?
-
 This part of the Sequencer makes playing sounds easy, including fading the sound in or out, playing for specific players, etc.
 
 ### How do I use this?
 
 When creating a sound section, you can assemble these methods like this:
-
 ```js
 new Sequence()
-  .sound()
-  .file("Music/Sound_Effects/Phoenix_Cry.wav")
-  .fadeInAudio(500)
-  .fadeOutAudio(500)
-  .play();
+    .sound()
+        .file("Music/Sound_Effects/Phoenix_Cry.wav")
+        .fadeInAudio(500)
+        .fadeOutAudio(500)
+    .play()
 ```
 
 <hr/>
@@ -54,7 +52,6 @@ It is highly recommended that you do not load too many files at the same time, a
 Causes the sound not play, and skip all delays, repetitions, waits, etc. If you pass a function, the function should return something false-y if you do not want the sound or sound to play.
 
 Below is an example of a function used in this method, which would cause this sound or sound to only be played about 50% of the time.
-
 ```js
 .playIf(() => {
 	return Math.random() < 0.5;
@@ -207,7 +204,7 @@ We recommend users and creators alike read the documentation on the [Sequencer d
 
 ## Add override
 
-Adds a function that will run at the end of the sound serialization step, but before it is played. Allows direct modifications of sound's data. For example, it could be manipulated to change which file will be used based on the distance to the target.
+Adds a function that will run at the end of the sound serialization step, but before it is played. Allows direct modifications of sound's data. For example, it could be manipulated to change which file will be used based  on the distance to the target.
 
 ```js
 .addOverride(async (sound, data) => {

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -17,28 +17,26 @@ If you're trying to play a sound, move a token, play effects on the canvas, hide
 To start off, create a new macro. You can do this by clicking any empty space in the hotbar. Remember to set your macro to type **script**.
 
 Now, type into the macro text field:
-
 ```js
-new Sequence();
+new Sequence()
 ```
-
 And you've started to work on the sequence! You might ask, "Why is there no variable? Why is it just `Sequence`, and nothing else?"
 
 That's because the Sequencer is something fancy called a "fluent interface". In short, you continuously work on the same thing, over and over. To make the sequence do something, you'll have to add a **section**.
 
 If you wanted to play a sound with this sequence, all you'd do is then:
-
 ```js
-new Sequence().sound("path/to/sound.wav");
+new Sequence()
+    .sound("path/to/sound.wav")
 ```
-
 From then on, all you're working on is the _sound_. Since you did `.sound()`, sequencer then knows that you're going to be working on that specific sound.
 
 But, that's not all, you'll have to tell the sequence that you want it to _play_.
-
 ```js
-new Sequence().sound("path/to/sound.wav").play();
-```
+new Sequence()
+    .sound("path/to/sound.wav")
+    .play()
+``` 
 
 Once you run this macro, the sequence will start, play the sound, and finish!
 
@@ -47,14 +45,12 @@ Keep in mind that `.play()` doesn't play the _sound_, it plays the _Sequence_. T
 ## Multiple sections
 
 Say for example that you wanted to play several sounds at the same time, you would simply do this:
-
 ```js
 new Sequence()
-  .sound("path/to/sound.wav")
-  .sound("path/to/another/sound.wav")
-  .play();
-```
-
+    .sound("path/to/sound.wav")
+    .sound("path/to/another/sound.wav")
+    .play()
+``` 
 Once you run this macro, you'll immediately play both sounds at the same time!
 
 ## What is a section?
@@ -62,11 +58,10 @@ Once you run this macro, you'll immediately play both sounds at the same time!
 When you write a sequence, you have to keep in mind that each part could be considered a "section". A section could be a sound section, or an effect section, or an animation section.
 
 When you write:
-
 ```js
-new Sequence().sound("path/to/sound.wav");
+new Sequence()
+    .sound("path/to/sound.wav")
 ```
-
 Anything you do from then on is working on the _sound section_ for the sound `path/to/sound.wav`. When you write another `.sound()` section after that one, you stop working on the first, and you're now working on the **new sound**.
 
 But what if you wanted the second sound to wait for the first to finish before playing?
@@ -76,15 +71,13 @@ But what if you wanted the second sound to wait for the first to finish before p
 Like I've said multiple times, when you first do `.sound()`, you then work on that sound section. That means that you can then put any of the [sound methods](api/sound.md) on it!
 
 For example, a sound can be made to wait until it finishes playing by adding `.waitUntilFinished()`, like this:
-
 ```js
 new Sequence()
-  .sound("path/to/sound.wav")
-  .waitUntilFinished()
-  .sound("path/to/another/sound.wav")
-  .play();
-```
-
+    .sound("path/to/sound.wav")
+        .waitUntilFinished()
+    .sound("path/to/another/sound.wav")
+    .play()
+``` 
 You see how I put `.waitUntilFinished()` further to the right than the rest of the code? That helps me identify that it is affecting the first sound. You don't have to do this, but it helps make the code easier to read.
 
 If you now run this macro, you'll play the first sound, then _wait until it finishes_, and then play the second sound.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,1095 +1,923 @@
 ## Changelog
 
 ### Version 3.0.0
-
-- _Sequencer_ - Updated Sequencer Database Viewer:
+- *Sequencer* - Updated Sequencer Database Viewer:
   - Improved UI and added nested tree view
-  - Added ctrl modifier to buttons that copy paths, which adds quotes around the copied paths
-- _Sequencer_ - Updated Sequencer Effect Player:
+  - Added ctrl modifier to buttons that copy paths, which adds quotes around the copied paths 
+- *Sequencer* - Updated Sequencer Effect Player:
   - Improved UI based on the design of MatthijsKok on github - thanks a lot for the inspiration!
-- _Sequencer_ - Reworked the Sequencer Effect Manager to the Sequencer Manager:
-  - Added the ability to stop running sounds
-  - Added a Sequence view where you can see the sequences as they are running, and stop the entire execution or their individual sections
-- _Sequencer_ - Added `.scrollingText()` which allows playing scrolling text on the canvas for users
-- _Sequencer_ - Added `.canvasPan()` which allows panning the canvas for connected users
-- _Sequencer_ - Added `.toJSON()` and `.fromJSON()` to Sequences to be able to be serialized and deserialized; only sequences with effects, sounds, scrolling texts, and canvas pans can be serialized
-- _Sequencer_ - Added options to `.play()`, which may contain an object; currently supports `{ remote: true/false }` which will serialize the sequence (see above), and send it to each client for local playback, instead of the person running the sequence sending data to clients as it is being executed
-- _Sequencer_ - Added database support for `_timestamps` metadata on effect files, which will trigger the `sequencerEffectTimestamp` hook when effects reach the point of the timestamps for that file
-- _Sequencer_ - Added support for flipbook-type effects through a `_flipbook` database tag
-- _Animations_ - Improved playback of movement, fade in/out, and rotation animations on tokens
-- _Effects_ - Added `CanvasEffect#addAnimatedProperties`, which will allow you to easily add animations to properties of existing effects
-- _Effects_ - Improved screenspace above UI effect performance by not rendering the extra canvas when not in use
-- _Effects_ - Fixed screenspace effects being affected by the vision mask
-- _Effects_ - Fixed `.stretchTo()` effects would be visible when not in vision
-- _Effects_ - Fixed `.fadeOut()` and `.scaleOut()` not working at all
-- _Effects_ - Reworked how effects are replicated on linked tokens when `.persist()`'s `persistPrototypeToken` is enabled, improving performance
+- *Sequencer* - Added `.scrollingText()` which allows to play scrolling text on the canvas for users
+- *Sequencer* - Added `.toJSON()` and `.fromJSON()` to Sequences to be able to be serialized and deserialized; only sequences with effects, sounds, and scrolling texts can be serialized
+- *Sequencer* - Added options to `.play()`, which may contain an object; currently supports `{ remote: true/false }` which will serialize the sequence (see above), and send it to each client for local playback, instead of the person running the sequence sending data to clients as it is being executed 
+- *Sequencer* - Added database support for `_timestamps` metadata on effect files, which will trigger the `sequencerEffectTimestamp` hook when effects reach the point of the timestamps for that file 
+- *Sequencer* - Added support for flipbook-type effects through a `_flipbook` database tag
+- *Effects* - Fixed `.stretchTo()` effects would be visible when not in vision
+- *Effects* - Fixed `.fadeOut()` and `.scaleOut()` not working at all
+- *Effects* - Vastly improved how effects are replicated on linked tokens when `.persist()`'s `persistPrototypeToken` is enabled
 
 ### Version 2.414
-
-- _Sequencer_ - Included missing CSS file
+- *Sequencer* - Included missing CSS file
 
 ### Version 2.413
-
-- _Sequencer_ - Added support for database paths that resolve to other database paths
-- _Sequencer_ - Isolated Sequencer's styling so that it doesn't leak out into other modules or systems
-- _Effects_ - Fixed `.loopProperty()` not respecting `loops: 0`
-- _Effects_ - Fixed `.animateProperty()` not keeping track of relative values when animating the same property multiple times
-- _Effects_ - Fixed named screenspace effects without a specific location not playing and throwing errors
-- _Sounds_ - Fixed `softFail` not allowing sounds to softly fail
+- *Sequencer* - Added support for database paths that resolve to other database paths
+- *Sequencer* - Isolated Sequencer's styling so that it doesn't leak out into other modules or systems
+- *Effects* - Fixed `.loopProperty()` not respecting `loops: 0`
+- *Effects* - Fixed `.animateProperty()` not keeping track of relative values when animating the same property multiple times
+- *Effects* - Fixed named screenspace effects without a specific location not playing and throwing errors
+- *Sounds* - Fixed `softFail` not allowing sounds to softly fail
 
 ### Version 2.412
-
-- _Sequencer_ - Added setting to hide/show the Sequencer buttons in the left sidebar when in the token controls
-- _Animation_ - Fixed `.moveTowards()` going into infinite loop if the source and targets are on top of each other
-- _Effects_ - Fixed `.shape()` taking grid size into account multiple times
-- _Effects_ - Fixed `.volume()`, `.fadeInAudio()`, and `.fadeOutAudio()` not working on webms with embedded audio
+- *Sequencer* - Added setting to hide/show the Sequencer buttons in the left sidebar when in the token controls
+- *Animation* - Fixed `.moveTowards()` going into infinite loop if the source and targets are on top of each other
+- *Effects* - Fixed `.shape()` taking grid size into account multiple times
+- *Effects* - Fixed `.volume()`, `.fadeInAudio()`, and `.fadeOutAudio()` not working on webms with embedded audio 
 
 ### Version 2.411
-
-- _Sequencer_ - Fixed infinite recursion when using `.waitUntilFinished()` in the middle of a sequence
-- _Sequencer_ - Undid some minor issues in the database viewer
+- *Sequencer* - Fixed infinite recursion when using `.waitUntilFinished()` in the middle of a sequence
+- *Sequencer* - Undid some minor issues in the database viewer
 
 ### Version 2.410
-
-- _Sequencer_ - Added support for playing sounds in the Sequencer Database (thank you ZotyDev for the pull request!)
-- _Sequencer_ - Calling methods on the sequence that it does not have will be attempted to be cast to the last section
-- _Sequencer_ - You can now provide `false` as an argument to `.waitUntilFinished()`, which will negate its call
-- _Effects_ - Fixed animations on `alphaFilter`'s `alpha` not working
+- *Sequencer* - Added support for playing sounds in the Sequencer Database (thank you ZotyDev for the pull request!)
+- *Sequencer* - Calling methods on the sequence that it does not have will be attempted to be cast to the last section
+- *Sequencer* - You can now provide `false` as an argument to `.waitUntilFinished()`, which will negate its call
+- *Effects* - Fixed animations on `alphaFilter`'s `alpha` not working
 
 ### Version 2.49
-
 - We don't talk about this version
 
 ### Version 2.4.8
-
-- _Effects_ - Fixed rectangle measurable templates would be off by 45 degrees
-- _Effects_ - Fixed tokens with locked rotation would cause attached effects to be rotated anyway
-- _Effects_ - Fixed `.tint()` not applying to `.stretchTo()` effects
+- *Effects* - Fixed rectangle measurable templates would be off by 45 degrees
+- *Effects* - Fixed tokens with locked rotation would cause attached effects to be rotated anyway
+- *Effects* - Fixed `.tint()` not applying to `.stretchTo()` effects
 
 ### Version 2.4.7
-
-- _Effects_ - Actually fixed shapes
+- *Effects* - Actually fixed shapes
 
 ### Version 2.4.6
-
-- _Effects_ - Fixed effects with only shapes would not play properly
-- _Effects_ - Fixed error when users tried to play effects even when `softFail` was set to `true`
+- *Effects* - Fixed effects with only shapes would not play properly
+- *Effects* - Fixed error when users tried to play effects even when `softFail` was set to `true`
 
 ### Version 2.4.5
-
-- _Effects_ - Fixed effects playing on the same scene as the user's current scene, even if the target of the effect was on another scene
-- _Effects_ - Fixed `.from()` not working with the new `softFail` sequence parameter
-- _Effects_ - Fixed being able to pass non-valid parameters to `.atLocation()` and similar functions without errors
+- *Effects* - Fixed effects playing on the same scene as the user's current scene, even if the target of the effect was on another scene
+- *Effects* - Fixed `.from()` not working with the new `softFail` sequence parameter
+- *Effects* - Fixed being able to pass non-valid parameters to `.atLocation()` and similar functions without errors
 
 ### Version 2.4.4
-
-- _Sequencer_ - Tweaked the arguments to `new Sequence("moduleName")` to `new Sequence(inOptions)` - it now takes a single object that can contain:
+- *Sequencer* - Tweaked the arguments to `new Sequence("moduleName")` to `new Sequence(inOptions)` - it now takes a single object that can contain:
   - `moduleName` <string> - The name of the module that is creating this sequence - this is for other users to know which module used Sequencer
   - `softFail` <boolean> - Setting this to `true` causes any failures to find files for effects, sounds, or macros to softly fail, rather than halt the entire sequence
-- _Effects_ - Tweaked `.shape()`s parent to be the `spriteContainer` rather than the `sprite`, so that animations to the sprite doesn't affect the shapes
-- _Effects_ - Fixed `.shape()` not considering their offset with `isMask` enabled
+- *Effects* - Tweaked `.shape()`s parent to be the `spriteContainer` rather than the `sprite`, so that animations to the sprite doesn't affect the shapes
+- *Effects* - Fixed `.shape()` not considering their offset with `isMask` enabled  
 
 ### Version 2.4.3
-
-- _Sequencer_ - Switched `Disable Pixi Fix` to `Enable Pixi Fix` to make it more consistent with other settings
-- _Sequencer_ - Added `Enable Global Pixi Fix` which fixes the alpha on animated tiles if enabled (use with caution)
-- _Effects_ - Fixed `.atLocation()` and `.persist()` throwing errors and thus failing to persist the effect on the scene
-- _Effects_ - Slight tweaks to visibility logic of effects to be more consistent
-- _Effects_ - Tweaked `.attachTo()`'s `align` and `edge` to not consider token scale when determining the edge of the token
+- *Sequencer* - Switched `Disable Pixi Fix` to `Enable Pixi Fix` to make it more consistent with other settings
+- *Sequencer* - Added `Enable Global Pixi Fix` which fixes the alpha on animated tiles if enabled (use with caution) 
+- *Effects* - Fixed `.atLocation()` and `.persist()` throwing errors and thus failing to persist the effect on the scene
+- *Effects* - Slight tweaks to visibility logic of effects to be more consistent
+- *Effects* - Tweaked `.attachTo()`'s `align` and `edge` to not consider token scale when determining the edge of the token
 
 ### Version 2.4.2
-
-- _Sequencer_ - Added `Sequencer.Presets` which allows you to create and save reusable bits of sequences
-- _Sequencer_ - Added `.preset()` which allows you to use the aforementioned presets
-- _Sequencer_ - Added optional `considerTokenScale` to the optional `options` parameter to `.scaleToObject()`, you can set it to `true` in order for the visual effect to also consider the token scale
-- _Sequencer_ - Added support for persistent visual effects on "fake" tokens created by Multilevel Tokens (only supports effects that are applied to the prototype token)
-- _Sequencer_ - Slightly improved the speed of document updates when visual effects are first applied
-- _Sequencer_ - Added a throttled console warning when the Photosensitive Mode is enabled and a client is trying to play effects (only warns once every 10 seconds when effects are played)
-- _Effects_ - Fixed `.scaleToObject()` always taking token scale into account, which it shouldn't do by default
+- *Sequencer* - Added `Sequencer.Presets` which allows you to create and save reusable bits of sequences
+- *Sequencer* - Added `.preset()` which allows you to use the aforementioned presets
+- *Sequencer* - Added optional `considerTokenScale` to the optional `options` parameter to `.scaleToObject()`, you can set it to `true` in order for the visual effect to also consider the token scale
+- *Sequencer* - Added support for persistent visual effects on "fake" tokens created by Multilevel Tokens (only supports effects that are applied to the prototype token) 
+- *Sequencer* - Slightly improved the speed of document updates when visual effects are first applied
+- *Sequencer* - Added a throttled console warning when the Photosensitive Mode is enabled and a client is trying to play effects (only warns once every 10 seconds when effects are played)
+- *Effects* - Fixed `.scaleToObject()` always taking token scale into account, which it shouldn't do by default
 
 ### Version 2.4.1
-
-- _Effects_ - Fixed minor typo in `.mask()`
+- *Effects* - Fixed minor typo in `.mask()`
 
 ### Version 2.4.0
-
-- _Sequencer_ - Added `Seqencer.EffectManager` to the autocomplete types
-- _Sequencer_ - Fixed minor issue with the Effect Manager sometimes trying to load non-existent effect data
-- _Effects_ - Added `.shape()`, which allows you to create simple shapes on the canvas
+- *Sequencer* - Added `Seqencer.EffectManager` to the autocomplete types
+- *Sequencer* - Fixed minor issue with the Effect Manager sometimes trying to load non-existent effect data
+- *Effects* - Added `.shape()`, which allows you to create simple shapes on the canvas
   - See: <https://fantasycomputer.works/FoundryVTT-Sequencer/#/api/effect?id=shape>
-- _Effects_ - Fixed `.attachTo()` would attempt to apply flags on temporary templates such as warpgate crosshairs
+- *Effects* - Fixed `.attachTo()` would attempt to apply flags on temporary templates such as warpgate crosshairs
 
 ### Version 2.3.21
-
-- _Sequencer_ - Fixed interaction with the `Advanced Macros` module past version 1.19.2 (Thanks MrVaux!)
-- _Sequencer_ - Fixed issue with `Sequencer.Helpers.shuffle_array` not handling complex arrays very well
-- _Effects_ - Fixed `.from()` not taking token scale into account
+- *Sequencer* - Fixed interaction with the `Advanced Macros` module past version 1.19.2 (Thanks MrVaux!)
+- *Sequencer* - Fixed issue with `Sequencer.Helpers.shuffle_array` not handling complex arrays very well
+- *Effects* - Fixed `.from()` not taking token scale into account
 
 ### Version 2.3.20
-
-- _Sounds_ - Fixed sounds not working
+- *Sounds* - Fixed sounds not working
 
 ### Version 2.3.19
-
-- _Sequencer_ - Created a new wiki for Sequencer:
-  - <https://fantasycomputer.works/FoundryVTT-Sequencer/>
-- _Sequencer_ - Added full support for Sequencer typings in the **_Monaco Macro Editor_** (thanks to laquasicinque for your initial work!)
-- _Sequencer_ - Changed all settings to use Foundry v10's `requiresReload` instead of reloading the app
-- _Sequencer_ - Removed compendium of sample macros, in favor of the new wiki
-- _Effects_ - Added further support for webm's loaded through S3 buckets (files with type `application/octet-stream` now supported)
-- _Sounds_ - Sounds' `.file()` now has a secondary parameter to allow a false-y primary input to soft fail, instead of halting the entire Sequence
+- *Sequencer* - Created a new wiki for Sequencer:
+  - <https://fantasycomputer.works/FoundryVTT-Sequencer/> 
+- *Sequencer* - Added full support for Sequencer typings in the ***Monaco Macro Editor*** (thanks to laquasicinque for your initial work!)
+- *Sequencer* - Changed all settings to use Foundry v10's `requiresReload` instead of reloading the app
+- *Sequencer* - Removed compendium of sample macros, in favor of the new wiki
+- *Effects* - Added further support for webm's loaded through S3 buckets (files with type `application/octet-stream` now supported)
+- *Sounds* - Sounds' `.file()` now has a secondary parameter to allow a false-y primary input to soft fail, instead of halting the entire Sequence
 
 ### Version 2.3.18
-
-- _Sequencer_ - Added support for Foundry's photosensitive setting, which disables all effects without impacting other functionality
-- _Sequencer_ - Fixed incompatibility with the Foundry team's **_A House Divided_** adventure, the scenes should no longer appear to have a dark overlay
-- _Sequencer_ - Updated `.macro()` to work with the latest version of the **_Advanced Macros_** module
+- *Sequencer* - Added support for Foundry's photosensitive setting, which disables all effects without impacting other functionality 
+- *Sequencer* - Fixed incompatibility with the Foundry team's ***A House Divided*** adventure, the scenes should no longer appear to have a dark overlay
+- *Sequencer* - Updated `.macro()` to work with the latest version of the ***Advanced Macros*** module
 
 ### Version 2.3.17
-
-- _Effects_ - Fixed `.tieToDocuments()` not working for embedded documents on unlinked tokens
+- *Effects* - Fixed `.tieToDocuments()` not working for embedded documents on unlinked tokens
 
 ### Version 2.3.16
-
-- _Effects_ - Adjusted approach when ending effects when using `.tieToDocuments()`
+- *Effects* - Adjusted approach when ending effects when using `.tieToDocuments()`
 
 ### Version 2.3.15
-
-- _Sequencer_ - Fixed registering similar named modules in the database would cause the second to not register properly
+- *Sequencer* - Fixed registering similar named modules in the database would cause the second to not register properly 
 
 ### Version 2.3.14
-
-- _Effects_ - ACTUALLY fixed `.tieToDocuments()` (send help)
+- *Effects* - ACTUALLY fixed `.tieToDocuments()` (send help)
 
 ### Version 2.3.13
-
-- _Effects_ - Fixed deeper issue with `.tieToDocuments()` as it was not recognizing actors or items as parents in respect to UUIDs
+- *Effects* - Fixed deeper issue with `.tieToDocuments()` as it was not recognizing actors or items as parents in respect to UUIDs
 
 ### Version 2.3.12
-
-- _Effects_ - Fixed `.missed()` and `.stretchTo()`'s `randomOffset` having weird interactions when `.name()` was used to play effects at target locations
-- _Effects_ - Fixed `.tieToDocuments()` throwing errors and not removing effects when the tied documents were deleted
+- *Effects* - Fixed `.missed()` and `.stretchTo()`'s `randomOffset` having weird interactions when `.name()` was used to play effects at target locations
+- *Effects* - Fixed `.tieToDocuments()` throwing errors and not removing effects when the tied documents were deleted 
 
 ### Version 2.3.11
-
-- _Sequencer_ - Added `Sequencer.Database.inverseFlattenedEntries` which is a map object with the key being the file path and the value being the database path for that file
-- _Effects_ - Added `bindElevation` (default `true`) as a secondary argument to `.attachTo()` which can be used to make effects not follow the target's elevation
-- _Effects_ - Made `.elevation()` be relative to the target of the effect by default, you can pass a secondary object with `absolute: true` to make it absolutely elevated on the scene
-- _Effects_ - Improved internal logic when trying to play effects on clients who have disabled them - previously it had a chance to throw an error when clients with effects disabled would run sequences that included effects (as they would not know the duration of the effect)
+- *Sequencer* - Added `Sequencer.Database.inverseFlattenedEntries` which is a map object with the key being the file path and the value being the database path for that file
+- *Effects* - Added `bindElevation` (default `true`) as a secondary argument to `.attachTo()` which can be used to make effects not follow the target's elevation
+- *Effects* - Made `.elevation()` be relative to the target of the effect by default, you can pass a secondary object with `absolute: true` to make it absolutely elevated on the scene
+- *Effects* - Improved internal logic when trying to play effects on clients who have disabled them - previously it had a chance to throw an error when clients with effects disabled would run sequences that included effects (as they would not know the duration of the effect)
 
 ### Version 2.3.10
-
-- _Effects_ - Fixed race condition when deleting multiple attached effects in a row would leave some lingering effects
+- *Effects* - Fixed race condition when deleting multiple attached effects in a row would leave some lingering effects
 
 ### Version 2.3.9
-
-- _Effects_ - Fixed effects sticking around after deleting the document they were attached to
-- _Effects_ - Fixed error when deleting documents relating to named effects
-- _Effects_ - Fixed setting the position of screenspace effects would not work
+- *Effects* - Fixed effects sticking around after deleting the document they were attached to
+- *Effects* - Fixed error when deleting documents relating to named effects
+- *Effects* - Fixed setting the position of screenspace effects would not work
 
 ### Version 2.3.8
-
-- _Sequencer_ - Removed double declaration of socketlib hook
-- _Effects_ - Fixed error if no scenes has been created yet
-- _Effects_ - Fixed screenspace effects not working without setting its location
-- _Effects_ - Fixed `.animateProperty()` not working very well with `width` and `height`
-- _Effects_ - Improved the way effects interacts with Foundry hooks (it is more efficient)
+- *Sequencer* - Removed double declaration of socketlib hook
+- *Effects* - Fixed error if no scenes has been created yet
+- *Effects* - Fixed screenspace effects not working without setting its location
+- *Effects* - Fixed `.animateProperty()` not working very well with `width` and `height`
+- *Effects* - Improved the way effects interacts with Foundry hooks (it is more efficient)
 
 ### Version 2.3.7
-
-- _Effects_ - Fixed `.rotateTowards()`'s `rotationOffset` parameter not working properly
+- *Effects* - Fixed `.rotateTowards()`'s `rotationOffset` parameter not working properly
 
 ### Version 2.3.6
-
-- _Effects_ - Fixed multiple `.attachTo()` and `.strechTo()` with `attach: true` sometimes causing crashes due to overloading Foundry's tick function
-- _Effects_ - Fixed ColorMatrix `hue` and `.animateProperty()` not working well together
-- _Effects_ - Fixed `.atLocation()` with `randomOffset: true` would cause weird effects with `.stretchTo()`
+- *Effects* - Fixed multiple `.attachTo()` and `.strechTo()` with `attach: true` sometimes causing crashes due to overloading Foundry's tick function
+- *Effects* - Fixed ColorMatrix `hue` and `.animateProperty()` not working well together
+- *Effects* - Fixed `.atLocation()` with `randomOffset: true` would cause weird effects with `.stretchTo()`
 
 ### Version 2.3.5
-
-- _Sequencer_ - Removed Ouija Board example macros, this is now a separate module made by md-mention2reply, check it out!
-  - <https://foundryvtt.com/packages/ouija-board-for-sequencer>
-- _Sequencer_ - Updated module manifest to be more V10 compatible
-- _Effects_ - Fixed ColorMatrix `hue` property to be able to be animated with `animateProperty()` and `.loopProperty()`
-- _Effects_ - Fixed `.mask()` not working with tiles or measurable templates
-- _Effects_ - Fixed mirror and random mirror X/Y not actually flipping the effect
+- *Sequencer* - Removed Ouija Board example macros, this is now a separate module made by md-mention2reply, check it out!
+    - <https://foundryvtt.com/packages/ouija-board-for-sequencer>
+- *Sequencer* - Updated module manifest to be more V10 compatible
+- *Effects* - Fixed ColorMatrix `hue` property to be able to be animated with `animateProperty()` and `.loopProperty()`
+- *Effects* - Fixed `.mask()` not working with tiles or measurable templates
+- *Effects* - Fixed mirror and random mirror X/Y not actually flipping the effect
 
 ### Version 2.3.4
-
-- _Animations_ - Fixed `.rotateTowards()` throwing update error
+- *Animations* - Fixed `.rotateTowards()` throwing update error
 
 ### Version 2.3.3
-
-- _Effects_ - Fixed code to remove deprecation warning when both `.mask()` and `.persist()` was used
-- _Effects_ - Fixed rare issue where the temporary template layer would not be initialized and would cause Sequencer to error and stop working
-- _Effects_ - Fixed Sequencer Effects Player deprecation warnings
-- _Effects_ - Added warning to console for players trying to play effects when they do not have permission to do so
+- *Effects* - Fixed code to remove deprecation warning when both `.mask()` and `.persist()` was used
+- *Effects* - Fixed rare issue where the temporary template layer would not be initialized and would cause Sequencer to error and stop working 
+- *Effects* - Fixed Sequencer Effects Player deprecation warnings
+- *Effects* - Added warning to console for players trying to play effects when they do not have permission to do so
   - I realize warnings is not desired in most cases, but this has been an ongoing point of support, so to preserve my own sanity, this is just how it is now.
 
 ### Version 2.3.2 (Both Foundry V9 and V10)
-
-- _Animation_ - Fixed `.rotateTowards()` throwing errors
-- _Effects_ - Fixed `.loopProperty()` with property `scale` would incorrectly scale effect
+- *Animation* - Fixed `.rotateTowards()` throwing errors
+- *Effects* - Fixed `.loopProperty()` with property `scale` would incorrectly scale effect
 
 ### Version 2.3.1
-
-- _Effects_ - Fixed `.from()` and `.mask()` throwing errors about missing files
+- *Effects* - Fixed `.from()` and `.mask()` throwing errors about missing files
 
 ### Version 2.3.0 (V10 only)
-
-- _Sequencer_ - Added Spanish localization (thanks to Git-GoR!)
-- _Effects_ - Re-enabled `scale.x` and `scale.y` on `.animateProperty()` and `.loopProperty()`
-- _Effects_ - Deprecated `.belowTokens()` and `.belowTiles()` in favor of `.elevation()` due to fundamental changes in Foundry's V10 update. These methods will be removed in a future update
-- _Effects_ - Fully removed deprecated methods: `.addPostOverride()`, `.reachTowards()`, `.gridSize()`, `.startPoint()`, `.endPoint()`
+- *Sequencer* - Added Spanish localization (thanks to Git-GoR!)
+- *Effects* - Re-enabled `scale.x` and `scale.y` on `.animateProperty()` and `.loopProperty()` 
+- *Effects* - Deprecated `.belowTokens()` and `.belowTiles()` in favor of `.elevation()` due to fundamental changes in Foundry's V10 update. These methods will be removed in a future update
+- *Effects* - Fully removed deprecated methods: `.addPostOverride()`, `.reachTowards()`, `.gridSize()`, `.startPoint()`, `.endPoint()`
 
 ### Version 2.2.4
-
-- _Effects_ - Fixed `.rotateTowards()`'s `rotationOffset` parameter not working properly
--
-
+- *Effects* - Fixed `.rotateTowards()`'s `rotationOffset` parameter not working properly
+- 
 ### Version 2.2.3
-
 - Re-released 2.2.2, git pulled a fast one and the changes in that version never got out
 
 ### Version 2.2.2
-
-- _Animation_ - Fixed `.rotateTowards()` throwing errors (again)
-- _Effects_ - Fixed `.atLocation()` with `randomOffset: true` would cause weird effects with `.stretchTo()`
-- _Effects_ - Fixed error that would sometimes pop up during startup if the template layer has not been initialized
+- *Animation* - Fixed `.rotateTowards()` throwing errors (again)
+- *Effects* - Fixed `.atLocation()` with `randomOffset: true` would cause weird effects with `.stretchTo()`
+- *Effects* - Fixed error that would sometimes pop up during startup if the template layer has not been initialized
 
 ### Version 2.2.1
-
-- _Animation_ - Fixed `.rotateTowards()` throwing errors
-- _Effects_ - Fixed `.loopProperty()` with property `scale` would incorrectly scale effect
--
-
+- *Animation* - Fixed `.rotateTowards()` throwing errors
+- *Effects* - Fixed `.loopProperty()` with property `scale` would incorrectly scale effect
+- 
 ### Version 2.2.0 (last V9 update, except maybe some bug fixes)
-
 **Additions:**
-
-- _Effects_ - Added `.tieToDocuments()` which allows you to tie an effect to Foundry documents - such as Active Effects or Tokens. When these are deleted, the effect is automatically ended.
-- _Effects_ - Added secondary `offset` parameter to `.atLocation()`, `.attachTo()`, `.rotateTowards()`, `.from()`, and `.stretchTo()` which can be used to offset the location of the source or target
+- *Effects* - Added `.tieToDocuments()` which allows you to tie an effect to Foundry documents - such as Active Effects or Tokens. When these are deleted, the effect is automatically ended.
+- *Effects* - Added secondary `offset` parameter to `.atLocation()`, `.attachTo()`, `.rotateTowards()`, `.from()`, and `.stretchTo()` which can be used to offset the location of the source or target
   - Note: This means that `.offset()` is becoming deprecated - it will remain for a few versions with a silent warning
-- _Effects_ - Added `.spriteScale()` which can be used to scale the sprite of the effect separately from `.scale()`
+- *Effects* - Added `.spriteScale()` which can be used to scale the sprite of the effect separately from `.scale()`
 
 **Tweaks:**
-
-- _Animations_ - Renamed `.rotateTowards()`'s secondary parameter's `offset` property to be more accurately named `rotationOffset`
-- _Effects_ - Upgraded `.animateProperty()` and `.loopProperty()` to be additive, which means two animations can now target the same property on the same effect
-- _Effects_ - Renamed `.rotateTowards()`'s secondary parameter's `offset` property to be more accurately named `rotationOffset`
+- *Animations* - Renamed `.rotateTowards()`'s secondary parameter's `offset` property to be more accurately named `rotationOffset`
+- *Effects* - Upgraded `.animateProperty()` and `.loopProperty()` to be additive, which means two animations can now target the same property on the same effect
+- *Effects* - Renamed `.rotateTowards()`'s secondary parameter's `offset` property to be more accurately named `rotationOffset`
 
 **Fixes:**
-
-- _Sequencer_ - Fixed issue where copying the file path of a Database entry that has multiple ranges would always copy the file path for the middle-most range
-- _Sequencer_ - Rewrote the database traversal method to be more robust and carry metadata down to lower children
-- _Effects_ - Fixed long-running issue with lag and performance impact from Sequencer on some computers - the cause was the `.screenSpace()` layers, which have now been reworked. A setting to disable the Above UI Screenspace effects layer has been added to further support impacted individuals.
-- _Effects_ - Fixed `randomOffset` secondary option on `.attachTo()` not working
-- _Effects_ - Fixed `.scaleToObject()` and `.scale()` not playing nicely together
-- _Effects_ - Fixed loop markers not properly working
+- *Sequencer* - Fixed issue where copying the file path of a Database entry that has multiple ranges would always copy the file path for the middle-most range
+- *Sequencer* - Rewrote the database traversal method to be more robust and carry metadata down to lower children
+- *Effects* - Fixed long-running issue with lag and performance impact from Sequencer on some computers - the cause was the `.screenSpace()` layers, which have now been reworked. A setting to disable the Above UI Screenspace effects layer has been added to further support impacted individuals.
+- *Effects* - Fixed `randomOffset` secondary option on `.attachTo()` not working
+- *Effects* - Fixed `.scaleToObject()` and `.scale()` not playing nicely together
+- *Effects* - Fixed loop markers not properly working
 
 ### Version 2.1.14
-
-- _Sequencer_ - Removed PIXI fix for Foundry .webm tiles to apply premultiplied alpha, native Foundry behavior is now active
-- _Effects_ - Fixed fatal canvas errors when `persistTokenPrototype` was active and masked to the target of the effect
-- _Effects_ - Added warning when using `persistTokenPrototype` with masks _other_ than masks applied to the source target
-- _Effects_ - Added support for `.file()` to override `.from()`'s file while keeping the other settings intact
-- _Effects_ - Improved robustness of placeable object document retrieval
+- *Sequencer* - Removed PIXI fix for Foundry .webm tiles to apply premultiplied alpha, native Foundry behavior is now active
+- *Effects* - Fixed fatal canvas errors when `persistTokenPrototype` was active and masked to the target of the effect
+- *Effects* - Added warning when using `persistTokenPrototype` with masks _other_ than masks applied to the source target
+- *Effects* - Added support for `.file()` to override `.from()`'s file while keeping the other settings intact
+- *Effects* - Improved robustness of placeable object document retrieval
 
 ### Version 2.1.13
-
-- _Sequencer_ - Removed stray `console.log`
-- _Sequencer_ - Fixed Ouija board macro error, slightly improved effect positioning
-- _Effects_ - Added `.spriteRotation()` which allows you set the rotation of the effect in place - this differs from `.rotate()` in the sense that this is applied only locally to the sprite, after any other offsets or transformations
+- *Sequencer* - Removed stray `console.log`
+- *Sequencer* - Fixed Ouija board macro error, slightly improved effect positioning
+- *Effects* - Added `.spriteRotation()` which allows you set the rotation of the effect in place - this differs from `.rotate()` in the sense that this is applied only locally to the sprite, after any other offsets or transformations
 
 ### Version 2.1.12
-
-- _Effects_ - Fixed `.strechTo()` with parameter `attachTo: true` resulting in no stretching
+- *Effects* - Fixed `.strechTo()` with parameter `attachTo: true` resulting in no stretching
 
 ### Version 2.1.11
-
-- _Effects_ - Fixed effects attached to temporary templates causing errors in core Foundry code
-- _Effects_ - Effects attached to temporary objects (like warpgate cursors) are now propagated to other clients (call `.locally()` to make it only appear for the creator)
+- *Effects* - Fixed effects attached to temporary templates causing errors in core Foundry code
+- *Effects* - Effects attached to temporary objects (like warpgate cursors) are now propagated to other clients (call `.locally()` to make it only appear for the creator)
 
 ### Version 2.1.10
+- *Sequencer* - Fixed Sequencer Effect Manager not accepting Foundry documents as object references when filtering for effects
+- *Sequencer* - Fixed Sequencer Effect Player showing private database entries
+- *Effects* - Fixed attached effects not showing up for non-GMs
 
-- _Sequencer_ - Fixed Sequencer Effect Manager not accepting Foundry documents as object references when filtering for effects
-- _Sequencer_ - Fixed Sequencer Effect Player showing private database entries
-- _Effects_ - Fixed attached effects not showing up for non-GMs
-
-### Version 2.1.9
-
-- _Sequencer_ - Unlocked keybinds so that users may configure their own keybinds for Sequencer's layers
-- _Sequencer_ - Added support for `minDelay` and `maxDelay` on `.waitUntilFinished()`, so you can now have a random wait delay between sections
-- _Effects_ - Added `fromEnd` to `.animateProperty()` which causes the animation to play at the end of the effect's duration
-- _Effects_ - Added `gridUnits` support to `.animateProperty()` and `.loopProperty()` when using `position.x` or `position.y` as the animated target
-- _Effects_ - Added `gridUnits` as a secondary option to both `.offset()` and `.spriteOffset()`
-- _Effects_ - Fixed persistent prototype token effects not applying on every instance of its token
-- _Effects_ - Fixed `.playbackRate()` only adjusting effect duration, and not the actual playback rate
+### Version 2.1.9 
+- *Sequencer* - Unlocked keybinds so that users may configure their own keybinds for Sequencer's layers
+- *Sequencer* - Added support for `minDelay` and `maxDelay` on `.waitUntilFinished()`, so you can now have a random wait delay between sections
+- *Effects* - Added `fromEnd` to `.animateProperty()` which causes the animation to play at the end of the effect's duration
+- *Effects* - Added `gridUnits` support to `.animateProperty()` and `.loopProperty()` when using `position.x` or `position.y` as the animated target
+- *Effects* - Added `gridUnits` as a secondary option to both `.offset()` and `.spriteOffset()`
+- *Effects* - Fixed persistent prototype token effects not applying on every instance of its token
+- *Effects* - Fixed `.playbackRate()` only adjusting effect duration, and not the actual playback rate
 
 ### Version 2.1.8
-
-- _Sequencer_ - Added setting to allow clients to disable Sequencer's PIXI alpha fix for base textures
+- *Sequencer* - Added setting to allow clients to disable Sequencer's PIXI alpha fix for base textures
 
 ### Version 2.1.7
-
-- _Effects_ - Fixed string normalization
+- *Effects* - Fixed string normalization
 
 ### Version 2.1.6
-
-- _Sequencer_ - Updated compendium of Sequencer macro samples
-- _Effects_ - Fixed finding effects by name with accents in them silently failing
-- _Effects_ - Fixed `.attachTo()` not following the target's rotation
+- *Sequencer* - Updated compendium of Sequencer macro samples
+- *Effects* - Fixed finding effects by name with accents in them silently failing
+- *Effects* - Fixed `.attachTo()` not following the target's rotation
 
 ### Version 2.1.5
-
-- _Effects_ - Fixed switching scenes would sometimes break effects
+- *Effects* - Fixed switching scenes would sometimes break effects
 
 ### Version 2.1.4
-
-- _Effects_ - Fixed issue with hovering over persistent effects attached to objects sometimes causing Foundry's layers to crash
-- _Effects_ - Fixed `.animateProperty()` and `.loopProperty()` applying grid-size ratio on animated scales
+- *Effects* - Fixed issue with hovering over persistent effects attached to objects sometimes causing Foundry's layers to crash
+- *Effects* - Fixed `.animateProperty()` and `.loopProperty()` applying grid-size ratio on animated scales
 
 ### Version 2.1.3
-
-- _Effects_ - Fixed attached effects disappearing
-- _Effects_ - Fixed `.randomOffset()` not randomly offsetting effects (still deprecated, see 2.1.0 release notes)
+- *Effects* - Fixed attached effects disappearing
+- *Effects* - Fixed `.randomOffset()` not randomly offsetting effects (still deprecated, see 2.1.0 release notes)
 
 ### Version 2.1.2 Hotfix
-
-- _Effects_ - Fixed effects sometimes not becoming visible
+- *Effects* - Fixed effects sometimes not becoming visible
 
 ### Version 2.1.1
-
-- _Sequencer_ - Fixed canvas layer bug that caused performance issues for some users
-- _Sequencer_ - Fixed missing default template causing some effects to not play properly
+- *Sequencer* - Fixed canvas layer bug that caused performance issues for some users
+- *Sequencer* - Fixed missing default template causing some effects to not play properly
 - Added `.aboveLighting()`, which causes the effect to always be visible, regardless of sight, fog of war, or walls.
   - Note that if an effect is attached to an object via `.attachTo()`, you may need to disable `bindVisibilty` if the object is hidden
-- _Effects_ - Fixed `.from()`, it now uses the object's image when the effect plays, rather than when the Sequence was first created
-- _Effects_ - Fixed highlight box when hovering over effects in the Effect Manager UI not taking effect rotation into account
-- _Effects_ - Fixed effects sometimes not fully following its attached object
+- *Effects* - Fixed `.from()`, it now uses the object's image when the effect plays, rather than when the Sequence was first created
+- *Effects* - Fixed highlight box when hovering over effects in the Effect Manager UI not taking effect rotation into account
+- *Effects* - Fixed effects sometimes not fully following its attached object 
 
 ### Version 2.1.0
-
 **Additions:**
-
-- _Sequencer_ - Added support for the Effect Manager to be able to manipulate effects on other scenes, which means you can now end effects on other scenes than the one you're on via the API
-- _Sequencer_ - Added secondary options parameter to `Sequencer.Database.getEntry`, where `softFail: true` will cause the method to not throw errors when an entry was not found.
-- _Sequencer_ - Added `Sequencer.EffectManager.getEffectPositionByName` which will allow you retrieve an effect's position by name, in real time
-- _Effects_ - Added `.mask()`, which can now clip-mask effects to only show them within tokens, templates, tiles, or drawings - this supports the [Walled Templates module](https://foundryvtt.com/packages/walledtemplates)!
-- _Effects_ - Added a secondary options parameter to `.persist()`, which can accept `persistTokenPrototype: true` to persist the effect on the token's prototype data, useful for active effect-based VFX
-- _Effects_ - Added vision masking - now token vision affects how much of an effect they can see
-- _Effects_ - Added `.xray()` which can be used to turn off vision masking on individual effects
-- _Effects_ - Added support in the Sequencer Database for internal effect loops, see the [documentation for more information](https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/How-to:-Sequencer-Database#Internal-loops)
-- _Effects_ - Added `edge` option to `.attachTo()`, which can be set to `inner`, `on`, or `outer` to align the effect on the attached object's edge when used with `align`
-- _Effects_ - Added `.screenSpaceAboveUI()`, which causes `.screenSpace()` effects to play above _all_ UI elements in Foundry (use with caution)
-- _Effects_ - Added options parameter to `.scaleToObject()`, which can be passed `uniform: true` to cause the scaling to always be uniform (it picks the largest dimension of the object)
-- _Macros_ - Added the ability to reference compendiums when creating `.macro()`s in sequences
+- *Sequencer* - Added support for the Effect Manager to be able to manipulate effects on other scenes, which means you can now end effects on other scenes than the one you're on via the API
+- *Sequencer* - Added secondary options parameter to `Sequencer.Database.getEntry`, where `softFail: true` will cause the method to not throw errors when an entry was not found. 
+- *Sequencer* - Added `Sequencer.EffectManager.getEffectPositionByName` which will allow you retrieve an effect's position by name, in real time
+- *Effects* - Added `.mask()`, which can now clip-mask effects to only show them within tokens, templates, tiles, or drawings - this supports the [Walled Templates module](https://foundryvtt.com/packages/walledtemplates)!
+- *Effects* - Added a secondary options parameter to `.persist()`, which can accept `persistTokenPrototype: true` to persist the effect on the token's prototype data, useful for active effect-based VFX
+- *Effects* - Added vision masking - now token vision affects how much of an effect they can see
+- *Effects* - Added `.xray()` which can be used to turn off vision masking on individual effects 
+- *Effects* - Added support in the Sequencer Database for internal effect loops, see the [documentation for more information](https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/How-to:-Sequencer-Database#Internal-loops)
+- *Effects* - Added `edge` option to `.attachTo()`, which can be set to `inner`, `on`, or `outer` to align the effect on the attached object's edge when used with `align` 
+- *Effects* - Added `.screenSpaceAboveUI()`, which causes `.screenSpace()` effects to play above _all_ UI elements in Foundry (use with caution)
+- *Effects* - Added options parameter to `.scaleToObject()`, which can be passed `uniform: true` to cause the scaling to always be uniform (it picks the largest dimension of the object)
+- *Macros* - Added the ability to reference compendiums when creating `.macro()`s in sequences
 
 **Fixes:**
-
-- _Sequencer_ - As `SequencerDatabase` was deprecated in 2.0.0 in favor of `Sequencer.Database`, the former has now been removed
-- _Sequencer_ - Adjusted Database methods with more validation so that searching with empty strings won't throw hard to read errors
-- _Sequencer_ - Removed bogus Effect Player warning about permissions that no longer reflects what Sequencer does
-- _Sequencer_ - Fixed some issues when copying and playing effects through the Database Viewer
-- _Effects_ - Fixed effects being invisible to players if the effect was created out of sight (thanks @dev7355608!)
-- _Effects_ - Fixed `align` on `.attachTo()` not working as expected when an effect's scale or size was set
-- _Effects_ - Fixed blur filter not taking given properties into account
-- _Effects_ - The following functions now have loud deprecation warnings:
-  - `.addPostOverride()`
-  - `.reachTowards()`
-  - `.gridSize()`
-  - `.startPoint()`
-  - `.endPoint()`
-- _Effects_ - Deprecated `.randomOffset()` in favor of adding `randomOffset` as a secondary argument on `.atLocation()`, `.stretchTo()`, `.rotateTowards()`, and `.attachTo()`
+- *Sequencer* - As `SequencerDatabase` was deprecated in 2.0.0 in favor of `Sequencer.Database`, the former has now been removed
+- *Sequencer* - Adjusted Database methods with more validation so that searching with empty strings won't throw hard to read errors
+- *Sequencer* - Removed bogus Effect Player warning about permissions that no longer reflects what Sequencer does
+- *Sequencer* - Fixed some issues when copying and playing effects through the Database Viewer
+- *Effects* - Fixed effects being invisible to players if the effect was created out of sight (thanks @dev7355608!)
+- *Effects* - Fixed `align` on `.attachTo()` not working as expected when an effect's scale or size was set
+- *Effects* - Fixed blur filter not taking given properties into account
+- *Effects* - The following functions now have loud deprecation warnings:
+    - `.addPostOverride()`
+    - `.reachTowards()`
+    - `.gridSize()`
+    - `.startPoint()`
+    - `.endPoint()`
+- *Effects* - Deprecated `.randomOffset()` in favor of adding `randomOffset` as a secondary argument on `.atLocation()`, `.stretchTo()`, `.rotateTowards()`, and `.attachTo()`
 
 ### Version 2.0.16
-
-- _Sequencer_ - Added japanese localization (thanks to the illustrious Brother Sharp#6921!)
+- *Sequencer* - Added japanese localization (thanks to the illustrious Brother Sharp#6921!)
 
 ### Version 2.0.15
-
-- _Effects_ - Fixed errors relating to tiling textures
-- _Effects_ - Fixed drifting effect animations when FPS dropped
-- _Effects_ - Improved performance relating to always updating the position of the sprites, even when attached objects weren't moving
-- _Effects_ - Hopefully fixed some memory leaks relating to assets not being deleted properly
-- _Effects_ - Fixed attached effects' rotations being funky
-- _Effects_ - Fixed effects attached to temporary objects (such as the warpgate crosshair) would not be properly removed from the effect manager
+- *Effects* - Fixed errors relating to tiling textures
+- *Effects* - Fixed drifting effect animations when FPS dropped
+- *Effects* - Improved performance relating to always updating the position of the sprites, even when attached objects weren't moving
+- *Effects* - Hopefully fixed some memory leaks relating to assets not being deleted properly 
+- *Effects* - Fixed attached effects' rotations being funky
+- *Effects* - Fixed effects attached to temporary objects (such as the warpgate crosshair) would not be properly removed from the effect manager 
 
 ### Version 2.0.14
-
-- _Database_ - Fixed the database sometimes getting confused by paths that have `ft` in them without being range-finding
-- _Effects_ - Fixed double-attached effects sometimes resulting in the sprite freezing (or in rare cases, browser crashes), though this type of effect is still expensive!
-- _Effects_ - Fixed `rotateTowards` with `attachTo` enabled not respecting actual target position end position
-- _Effects_ - Fixed `.rotation()` with `.loopProperty()` on the `spriteContainer`'s `rotation` causing rotational strangeness
-- _Effects_ - Fixed `.repeat()` with partial database path not picking random images for each repetition
-- _Sounds_ - Fixed error when playing sounds
+- *Database* - Fixed the database sometimes getting confused by paths that have `ft` in them without being range-finding
+- *Effects* - Fixed double-attached effects sometimes resulting in the sprite freezing (or in rare cases, browser crashes), though this type of effect is still expensive!
+- *Effects* - Fixed `rotateTowards` with `attachTo` enabled not respecting actual target position end position
+- *Effects* - Fixed `.rotation()` with `.loopProperty()` on the `spriteContainer`'s `rotation` causing rotational strangeness
+- *Effects* - Fixed `.repeat()` with partial database path not picking random images for each repetition
+- *Sounds* - Fixed error when playing sounds
 
 ### Version 2.0.13
-
-- _Effects_ - Fixed flipped tiles and measurable templates (with negative width or height) causing effects to not play on the correct location
-- _Effects_ - Fixed `.rotateTowards()` not following the rotation of attached objects
-- _Sounds_ - Fixed `.fadeInAudio()` and `.fadeOutAudio()` being broken
+- *Effects* - Fixed flipped tiles and measurable templates (with negative width or height) causing effects to not play on the correct location
+- *Effects* - Fixed `.rotateTowards()` not following the rotation of attached objects
+- *Sounds* - Fixed `.fadeInAudio()` and `.fadeOutAudio()` being broken
 
 ### Version 2.0.12
-
-- _Effects_ - Fixed effects with only `.text()` and no `.file()` not working properly
-- _Effects_ - Fixed `.text()` combined with `.screenSpace()` would not be scaled properly
+- *Effects* - Fixed effects with only `.text()` and no `.file()` not working properly
+- *Effects* - Fixed `.text()` combined with `.screenSpace()` would not be scaled properly 
 
 ### Version 2.0.11
-
-- _Effects_ - Fixed `.extraEndDuration()` not working properly when `.waitUntilFinished()` was provided a negative number
-- _Effects_ - Fixed `.noLoop()` effects sometimes not reaching their proper end time when `.endTime()`, `.endTimePerc()` or `.timeRange()` was used
+- *Effects* - Fixed `.extraEndDuration()` not working properly when `.waitUntilFinished()` was provided a negative number
+- *Effects* - Fixed `.noLoop()` effects sometimes not reaching their proper end time when `.endTime()`, `.endTimePerc()` or `.timeRange()` was used
 
 ### Version 2.0.10
-
-- _Sequencer_ - Fixed error in `Database.validateEntries()`
-- _Sequencer_ - Updated `pre` hooks to cancel the action if any function return `false`
-- _Sequencer_ - Updated Rope and Chain macros in compendium
-- _Effects_ - Added `.tilingTexture()` - this will replace the `tiling` parameter on `.stretchTo()` in the long term
-- _Effects_ - Deleting the object an effect is attached to will now actually trigger the effect's `.fadeOut()`, `.scaleOut()` etc
+- *Sequencer* - Fixed error in `Database.validateEntries()`
+- *Sequencer* - Updated `pre` hooks to cancel the action if any function return `false`
+- *Sequencer* - Updated Rope and Chain macros in compendium
+- *Effects* - Added `.tilingTexture()` - this will replace the `tiling` parameter on `.stretchTo()` in the long term
+- *Effects* - Deleting the object an effect is attached to will now actually trigger the effect's `.fadeOut()`, `.scaleOut()` etc
 
 ### Version 2.0.9 Hotfix
-
-- _Effects_ - Fixed nasty issue with rotation on effects
-- _Effects_ - Made all effects have an assumed internal grid size of 100
+- *Effects* - Fixed nasty issue with rotation on effects
+- *Effects* - Made all effects have an assumed internal grid size of 100
 
 ### Version 2.0.8
-
-- _Sequencer_ - Added rope and chain sample macros to the Sequencer macro compendium
-- _Sequencer_ - Removed non-functional Chain Lightning macro from macro collection
-- _Sequencer_ - Added warnings to Preloader when it is given invalid parameters
-- _Effects_ - Added `tiling` as an option to `.stretchTo()`
-- _Effects_ - Fixed `.randomRotation()` not working with `.attachTo()`
-- _Effects_ - Fixed issue with effects with a defined width and height were still being scaled by the scene-effect grid size difference
+- *Sequencer* - Added rope and chain sample macros to the Sequencer macro compendium
+- *Sequencer* - Removed non-functional Chain Lightning macro from macro collection
+- *Sequencer* - Added warnings to Preloader when it is given invalid parameters
+- *Effects* - Added `tiling` as an option to `.stretchTo()`
+- *Effects* - Fixed `.randomRotation()` not working with `.attachTo()`
+- *Effects* - Fixed issue with effects with a defined width and height were still being scaled by the scene-effect grid size difference
 
 ### Version 2.0.7
-
-- _Sequencer_ - Fixed broken macro in the Ouija example
-- _Animations_ - Fixed various animation methods not resulting accurate movement or teleportation
-- _Effects_ - Fixed `.randomRotation()` not working
+- *Sequencer* - Fixed broken macro in the Ouija example
+- *Animations* - Fixed various animation methods not resulting accurate movement or teleportation
+- *Effects* - Fixed `.randomRotation()` not working
 
 ### Version 2.0.6
-
-- _Sequencer_ - Improved intelligence of webm cache
-- _Effects_ - Added `.private()` method to hide effects in the effect manager - DO NOT USE IF YOU DO NOT KNOW WHAT YOU ARE DOING
-- _Effects_ - Fixed issue where ending effects by name would cause other effects without a name to get \_ended
-- _Effects_ - Fixed issue where filtering for effects with the Effect Manager would cause it to split the given name on each whitespace
+- *Sequencer* - Improved intelligence of webm cache 
+- *Effects* - Added `.private()` method to hide effects in the effect manager - DO NOT USE IF YOU DO NOT KNOW WHAT YOU ARE DOING
+- *Effects* - Fixed issue where ending effects by name would cause other effects without a name to get _ended
+- *Effects* - Fixed issue where filtering for effects with the Effect Manager would cause it to split the given name on each whitespace 
 
 ### Version 2.0.5 Hotfix Hotfix
-
-- _Effects_ - Hotfix for the hotfix. It's just hotfixes all the way down, man.
+- *Effects* - Hotfix for the hotfix. It's just hotfixes all the way down, man.
 
 ### Version 2.0.4 Hotfix
-
-- _Effects_ - Fixed some modules causing Sequencer to complain
-- _Effects_ - Actually fixed copying objects would not copy the effects on it
+- *Effects* - Fixed some modules causing Sequencer to complain 
+- *Effects* - Actually fixed copying objects would not copy the effects on it
 
 ### Version 2.0.3
-
-- _Effects_ - Fixed some issues regarding file paths on ForgeVTT, though they did most of the legwork on their side
-- _Effects_ - Fixed issue where `.scaleToObject()` would fail to scale to the object properly
-- _Effects_ - Fixed Effect Manager not finding effects to end when it was only provided an object
-- _Effects_ - Fixed copying tokens and other objects with ongoing effects would not properly play it for everyone
-- _Effects_ - Fixed screenspace effects would sometimes not play properly
+- *Effects* - Fixed some issues regarding file paths on ForgeVTT, though they did most of the legwork on their side
+- *Effects* - Fixed issue where `.scaleToObject()` would fail to scale to the object properly
+- *Effects* - Fixed Effect Manager not finding effects to end when it was only provided an object
+- *Effects* - Fixed copying tokens and other objects with ongoing effects would not properly play it for everyone
+- *Effects* - Fixed screenspace effects would sometimes not play properly 
 
 ### Version 2.0.2
-
-- _Sequencer_ - Fixed the preloader throwing error about recursion
-- _Effects_ - Fixed rotational animations not working properly
-- _Effects_ - Fixed the update interface not allowing attribute paths like core Foundry does
-- _Effects_ - Fixed effects lingering for other users after their attached objects were deleted
-- _Effects_ - Fixed issues with using `.from()` on tiles
+- *Sequencer* - Fixed the preloader throwing error about recursion
+- *Effects* - Fixed rotational animations not working properly
+- *Effects* - Fixed the update interface not allowing attribute paths like core Foundry does
+- *Effects* - Fixed effects lingering for other users after their attached objects were deleted
+- *Effects* - Fixed issues with using `.from()` on tiles
 
 ### Version 2.0.1
-
-- _Sequencer_ - Fixed preloader throwing error about missing functions
-- _Sequencer_ - Fixed Effect Manager complaining if trying to filter effects by name while some effects didn't have a valid name
-- _Effects_ - Added the ability to use Effects as elements to play other Effects on
-- _Effects_ - Added cache-busting for when the Sequencer .webm cache would get larger than 1GB
-- _Effects_ - Fixed persistent effects attached to WarpGate crosshairs throwing errors
-- _Effects_ - Fixed `cacheLocation` throwing errors regarding missing function
-- _Effects_ - Fixed `endedSequencerEffect` being called too late for users to be able to use its parameters
-- _Effects_ - Fixed error when deleting the object an effect was attached to through both `.attachTo()` and `.stretchTo()`
+- *Sequencer* - Fixed preloader throwing error about missing functions
+- *Sequencer* - Fixed Effect Manager complaining if trying to filter effects by name while some effects didn't have a valid name
+- *Effects* - Added the ability to use Effects as elements to play other Effects on
+- *Effects* - Added cache-busting for when the Sequencer .webm cache would get larger than 1GB
+- *Effects* - Fixed persistent effects attached to WarpGate crosshairs throwing errors
+- *Effects* - Fixed `cacheLocation` throwing errors regarding missing function
+- *Effects* - Fixed `endedSequencerEffect` being called too late for users to be able to use its parameters
+- *Effects* - Fixed error when deleting the object an effect was attached to through both `.attachTo()` and `.stretchTo()` 
 
 ### Version 2.0.0
-
 **Breaking changes:**
-
-- _Sequencer_ - Sequencer now requires the `socketlib` module
-- _Sequencer_ - All existing persistent effects created using 1.X.X Sequencer will be updated to the 2.0.0 system, but it's nigh impossible to catch all the edge cases, so please report any strangeness!
-- _Effects_ - Removed support for audio methods on effects (hardly used and caused a whole host of problems)
-- _Effects_ - Deprecated `.reachTowards()` and renamed it to `.stretchTo()`. The deprecated method will be removed in 2.1.0.
-- _Effects_ - Deprecated `.addPostOverride()`, please use `.addOverride()` instead. The deprecated method will be removed in 2.1.0.
-- _Effects_ - Deprecated `.gridSize()`, `.startPoint()`, and `.endPoint()` in favor for `.template({ gridSize, startPoint, endPoint })`. The deprecated methods will be removed in 2.1.0.
-- _Effects_ - Removed deprecated method `.JB2A()`
+- *Sequencer* - Sequencer now requires the `socketlib` module
+- *Sequencer* - All existing persistent effects created using 1.X.X Sequencer will be updated to the 2.0.0 system, but it's nigh impossible to catch all the edge cases, so please report any strangeness!
+- *Effects* - Removed support for audio methods on effects (hardly used and caused a whole host of problems)
+- *Effects* - Deprecated `.reachTowards()` and renamed it to `.stretchTo()`. The deprecated method will be removed in 2.1.0.
+- *Effects* - Deprecated `.addPostOverride()`, please use `.addOverride()` instead. The deprecated method will be removed in 2.1.0.
+- *Effects* - Deprecated `.gridSize()`, `.startPoint()`, and `.endPoint()` in favor for `.template({ gridSize, startPoint, endPoint })`. The deprecated methods will be removed in 2.1.0.
+- *Effects* - Removed deprecated method `.JB2A()`
 
 **Tweaks:**
-
-- _Sounds & Effects_ - Tweaked `.forUsers()` to also accept player names (case-sensitive) instead of just IDs
-- _Effects_ - Tweaked attached effects' layer handling - effects can now be attached but exist below _all_ Tokens, for example
-- _Effects_ - Tweaked `.filter()` to allow being called multiple times, which now layers the filters in the order they were created
+- *Sounds & Effects* - Tweaked `.forUsers()` to also accept player names (case-sensitive) instead of just IDs
+- *Effects* - Tweaked attached effects' layer handling - effects can now be attached but exist below _all_ Tokens, for example
+- *Effects* - Tweaked `.filter()` to allow being called multiple times, which now layers the filters in the order they were created
 
 **Additions:**
-
-- _Sequencer_ - Added selection tool to the Effect Layer - select, move, reattach, and delete effects on the canvas!
-- _Sequencer_ - Added `updateEffects` to the Effect Manager's API
-- _Sequencer_ - Added `updateSequencerEffect` hook
-- _Sequencer_ - Added support to `.macro()`s to be able to supply additional arguments (requires the Advanced Macros module)
-- _Sequencer_ - Added wildcard support when filtering for named effects in the Effect Manager's API (such as `getEffects`, `endEffects`, etc)
-- _Sequencer_ - Added support to filter for `source` and `target` in the Effect Manager's API (such as `getEffects`, `endEffects`, etc)
-- _Sequencer_ - Added "private" boolean flag to `Sequencer.Database.registerEntries()` which causes the entries to not be visible in the Database Viewer and Effect Player
-- _Sequencer_ - Added Setting to be able to hide Sequencer's tools on the toolbar
-- _Sequencer_ - Added checkbox to Database Viewer to show all ranges of a single effect, which is by default set to false
-- _Sequencer_ - Added `Sequencer.Helpers`, a library of useful methods - check them out on the wiki: https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/Sequencer-Helper-Functions
-- _Animations_ - Added `.hide()` and `.show()` to hide or show the animated object
-- _Effects_ - Added more secondary options parameters to `.stretchTo()`, which accepts:
-  - At long last, this can now `attachTo` (boolean) to the given target. Combine with `.attachTo()` to link an effect between two tokens!
-  - `onlyX` (boolean), if set to true, this will cause stretchTo to only stretch the X axis of the sprite towards the target (keeping Y at 1.0, or your given scale)
-- _Effects_ - Added support to `.file()` for an object map containing the feet range and filepath key-value pair. Check out the file wiki entry to understand what this means: https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/Effects#file
-- _Effects_ - Added secondary options parameter to `.attachTo()`, which accepts:
-  - `align` (string, default "center"), accepts `top-left`, `center`, `left`, `bottom-right`, etc. Read the wiki: https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/Effects#attach-to
-  - `bindVisibility` (boolean, default true), if set to false, the effect will not be hidden if the attached object is hidden
-  - `bindAlpha` (boolean, default true), if set to false, the effect's alpha will be independent of the attached object
-  - `followRotation` (boolean, default true), if set to false, the effect will not follow the rotation of the attached object
-- _Effects_ - Added options to `.size()` which allows for `{ gridUnits: true }` - this makes the size given to the method scale to the scene's grid, instead of setting the exact width and height
-- _Effects_ - Added the same option as above to `.animateProperty()` and `.loopProperty()`, which only works if you animate the `width` or `height`
+- *Sequencer* - Added selection tool to the Effect Layer - select, move, reattach, and delete effects on the canvas!
+- *Sequencer* - Added `updateEffects` to the Effect Manager's API
+- *Sequencer* - Added `updateSequencerEffect` hook
+- *Sequencer* - Added support to `.macro()`s to be able to supply additional arguments (requires the Advanced Macros module)
+- *Sequencer* - Added wildcard support when filtering for named effects in the Effect Manager's API (such as `getEffects`, `endEffects`, etc)
+- *Sequencer* - Added support to filter for `source` and `target` in the Effect Manager's API (such as `getEffects`, `endEffects`, etc)
+- *Sequencer* - Added "private" boolean flag to `Sequencer.Database.registerEntries()` which causes the entries to not be visible in the Database Viewer and Effect Player
+- *Sequencer* - Added Setting to be able to hide Sequencer's tools on the toolbar
+- *Sequencer* - Added checkbox to Database Viewer to show all ranges of a single effect, which is by default set to false
+- *Sequencer* - Added `Sequencer.Helpers`, a library of useful methods - check them out on the wiki: https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/Sequencer-Helper-Functions
+- *Animations* - Added `.hide()` and `.show()` to hide or show the animated object
+- *Effects* - Added more secondary options parameters to `.stretchTo()`, which accepts:
+    - At long last, this can now `attachTo` (boolean) to the given target. Combine with `.attachTo()` to link an effect between two tokens!
+    - `onlyX` (boolean), if set to true, this will cause stretchTo to only stretch the X axis of the sprite towards the target (keeping Y at 1.0, or your given scale)
+- *Effects* - Added support to `.file()` for an object map containing the feet range and filepath key-value pair. Check out the file wiki entry to understand what this means: https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/Effects#file
+- *Effects* - Added secondary options parameter to `.attachTo()`, which accepts:
+    - `align` (string, default "center"), accepts `top-left`, `center`, `left`, `bottom-right`, etc. Read the wiki: https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/Effects#attach-to
+    - `bindVisibility` (boolean, default true), if set to false, the effect will not be hidden if the attached object is hidden
+    - `bindAlpha` (boolean, default true), if set to false, the effect's alpha will be independent of the attached object
+    - `followRotation` (boolean, default true), if set to false, the effect will not follow the rotation of the attached object
+- *Effects* - Added options to `.size()` which allows for `{ gridUnits: true }` - this makes the size given to the method scale to the scene's grid, instead of setting the exact width and height
+- *Effects* - Added the same option as above to `.animateProperty()` and `.loopProperty()`, which only works if you animate the `width` or `height`
 
 **Fixes:**
-
-- _Sequencer_ - Fixed module permissions settings being slightly wonky
-- _Sequencer_ - Fixed number inputs not throwing errors on `NaN` values
-- _Animations_ - Fixed users not being able to teleport or move tokens they do not own
-- _Animations_ - Fixed `.moveSpeed()` not affecting the duration of the animation
-- _Animations_ - Fixed `.delay()` not being respected
-- _Effects_ - Fixed memory leak where effect textures were not properly destroyed
-- _Effects_ - Adjusted `.origin()` to be able to accept a `Document` object to infer the UUID from
-- _Effects_ - Fixed `.from()` not taking mirror x/y into account on tokens
-- _Effects_ - Tokens with effects attached to them can now be \_ended by anyone who can update the token (owners of the token, GMs, etc)
-- _Effects_ - Increased default resolution of `.text()` to 10 (should increase quality)
-- _Effects_ - Fixed `.screenSpace()` effects still being affected by grid size normalization
+- *Sequencer* - Fixed module permissions settings being slightly wonky
+- *Sequencer* - Fixed number inputs not throwing errors on `NaN` values
+- *Animations* - Fixed users not being able to teleport or move tokens they do not own
+- *Animations* - Fixed `.moveSpeed()` not affecting the duration of the animation
+- *Animations* - Fixed `.delay()` not being respected
+- *Effects* - Fixed memory leak where effect textures were not properly destroyed
+- *Effects* - Adjusted `.origin()` to be able to accept a `Document` object to infer the UUID from
+- *Effects* - Fixed `.from()` not taking mirror x/y into account on tokens
+- *Effects* - Tokens with effects attached to them can now be _ended by anyone who can update the token (owners of the token, GMs, etc)
+- *Effects* - Increased default resolution of `.text()` to 10 (should increase quality)
+- *Effects* - Fixed `.screenSpace()` effects still being affected by grid size normalization
 
 ### Version 1.3.5
-
-- _Sequencer_ - Fixed Permissions being broken in the latest Foundry update, and moved Sequencer specific permissions into module settings instead
-- _Effects_ - <img src="images/siren.gif" width="18px" height="18px" alt="Siren"> Breaking change <img src="images/siren.gif" width="18px" height="18px" alt="Siren"> - Fixed issue where setting the `.size()` of an effect and then scaling it would result in unexpected behavior. As a result, `.scaleIn()` and `.scaleOut()` now function as _multipliers_ to the existing scale on the effect
+- *Sequencer* - Fixed Permissions being broken in the latest Foundry update, and moved Sequencer specific permissions into module settings instead
+- *Effects* - <img src="images/siren.gif" width="18px" height="18px" alt="Siren"> Breaking change <img src="images/siren.gif" width="18px" height="18px" alt="Siren"> - Fixed issue where setting the `.size()` of an effect and then scaling it would result in unexpected behavior. As a result, `.scaleIn()` and `.scaleOut()` now function as _multipliers_ to the existing scale on the effect
 
 ### Version 1.3.4
-
-- _Sequencer_ - Added popup warning the first time a GM opens the Effect Player to tell them about the custom Permissions
-- _Sequencer_ - Added button to open Foundry's Permissions directly from the Effect Player how-to page
+- *Sequencer* - Added popup warning the first time a GM opens the Effect Player to tell them about the custom Permissions
+- *Sequencer* - Added button to open Foundry's Permissions directly from the Effect Player how-to page
 
 ### Version 1.3.3
-
-- _Sounds_ - Fixed `.fadeInAudio()` and `.fadeOutAudio()` being broken
+- *Sounds* - Fixed `.fadeInAudio()` and `.fadeOutAudio()` being broken
 
 ### Version 1.3.2
-
-- _Sequencer_ - Minor backend updates to flag handling
-- _Effects_ - Fixed static images failing to load in v9
-- _Effects_ - Fixed effects attached to tokens that were copied to another scene would not play
-- _Effects_ - Suppressed recent deprecation warnings until the next release
-- _Effects_ - Reverted some code that would break persisting effects
+- *Sequencer* - Minor backend updates to flag handling
+- *Effects* - Fixed static images failing to load in v9
+- *Effects* - Fixed effects attached to tokens that were copied to another scene would not play
+- *Effects* - Suppressed recent deprecation warnings until the next release
+- *Effects* - Reverted some code that would break persisting effects
 
 ### Version 1.3.1
-
-- _Sequencer_ - Fixed minor spelling issue
+- *Sequencer* - Fixed minor spelling issue
 
 ### Version 1.3.0
-
-- _Sequencer_ - Sequencer is now v9 ready!
-- _Sequencer_ - Improved search accuracy functionality on the Effect Player
-- _Animations_ - Added `relativeToCenter` option to `.teleportTo()` and `.moveTowards()`, which will offset the location relative to the object's center, effectively centering the animated object on the location - use with `.snapToGrid()` for reliable snapping!
-- _Animations_ - Fixed `.fadeOut()`, `.fadeOutAudio()`, and `.rotateOut()` not correctly setting the duration of the animation, causing `.waitUntilFinished()` to not actually wait for the animation to finish
-- _Effects_ - Deprecated `.JB2A()` as the recommended workflow is now to use Database paths
+- *Sequencer* - Sequencer is now v9 ready!
+- *Sequencer* - Improved search accuracy functionality on the Effect Player
+- *Animations* - Added `relativeToCenter` option to `.teleportTo()` and `.moveTowards()`, which will offset the location relative to the object's center, effectively centering the animated object on the location - use with `.snapToGrid()` for reliable snapping!
+- *Animations* - Fixed `.fadeOut()`, `.fadeOutAudio()`, and `.rotateOut()` not correctly setting the duration of the animation, causing `.waitUntilFinished()` to not actually wait for the animation to finish
+- *Effects* - Deprecated `.JB2A()` as the recommended workflow is now to use Database paths
 
 ### Version 1.2.12 Hotfix
-
-- _Effects_ - Fixed `.animateProperty()` and `.loopProperty()` applying animations that were already complete
+- *Effects* - Fixed `.animateProperty()` and `.loopProperty()` applying animations that were already complete
 
 ### Version 1.2.11
-
-- _Sequencer_ - Added French localization (thanks to Elfenduil)
-- _Sequencer_ - Fixed error with `Sequencer.Database.validateEntries()` throwing an error
-- _Effects_ - Improved handling of the `Glow` filter when used with `.fadeIn()` and `.fadeOut()`
-  - Due to this change, it is now recommended that if you use `.animateProperty()` or `.loopProperty()` on the `sprite`'s `alpha` property to instead use it on the `alphaFilter`'s `alpha` property
-- _Macros_ - Updated the Misty Step macro to be more generic and not specifically _require_ MidiQOL
+- *Sequencer* - Added French localization (thanks to Elfenduil)
+- *Sequencer* - Fixed error with `Sequencer.Database.validateEntries()` throwing an error
+- *Effects* - Improved handling of the `Glow` filter when used with `.fadeIn()` and `.fadeOut()`
+    - Due to this change, it is now recommended that if you use `.animateProperty()` or `.loopProperty()` on the `sprite`'s `alpha` property to instead use it on the `alphaFilter`'s `alpha` property
+- *Macros* - Updated the Misty Step macro to be more generic and not specifically _require_ MidiQOL
 
 ### Version 1.2.10
-
-- _Sequencer_ - Fixed misspelled permission which caused players to not be able to see the toolbar buttons
-- _Sequencer_ - Added `End All Effects` button to the Effect Manager
+- *Sequencer* - Fixed misspelled permission which caused players to not be able to see the toolbar buttons
+- *Sequencer* - Added `End All Effects` button to the Effect Manager
 
 ### Version 1.2.9
-
-- _Sequencer_ - Removed error from the Effect Manager when no effects were removed
-- _Effects_ - Fixed `.randomOffset()` on tiles would result in pretty crazy behavior
+- *Sequencer* - Removed error from the Effect Manager when no effects were removed
+- *Effects* - Fixed `.randomOffset()` on tiles would result in pretty crazy behavior
 
 ### Version 1.2.8
-
-- _Sequencer_ - Added sidebar tool permissions, you can now hide them from players
-- _Effects_ - Added `.origin()` which provides a way to tag an effect with a string you can then search for with the Effect Manager
-- _Effects_ - Added support for using both `.reachTowards()` and `.scale()` and will now scale the effect whilst keeping the range finding correct
+- *Sequencer* - Added sidebar tool permissions, you can now hide them from players
+- *Effects* - Added `.origin()` which provides a way to tag an effect with a string you can then search for with the Effect Manager
+- *Effects* - Added support for using both `.reachTowards()` and `.scale()` and will now scale the effect whilst keeping the range finding correct
 
 ### Version 1.2.7 Hotfix
-
-- _Sounds_ - ACTUALLY Fixed sounds being broken
+- *Sounds* - ACTUALLY Fixed sounds being broken
 
 ### Version 1.2.6 Hotfix
-
-- _Sounds_ - Fixed sounds being broken
+- *Sounds* - Fixed sounds being broken
 
 ### Version 1.2.5
-
-- _Sequencer_ - Made hooks `createSequencerEffect` and `endedSequencerEffect` instead supply the CanvasEffect itself, rather than its data
-- _Effects_ - Fixed bug that caused effects to linger for other clients after having been \_ended
+- *Sequencer* - Made hooks `createSequencerEffect` and `endedSequencerEffect` instead supply the CanvasEffect itself, rather than its data
+- *Effects* - Fixed bug that caused effects to linger for other clients after having been _ended
 
 ### Version 1.2.4
-
-- _Sequencer_ - Fixed error caused by preload option on Sequencer Effect Player
-- _Sequencer_ - Fixed error when pressing ESC in the Sequencer Layer
-- _Sequencer_ - Fixed permissions not being loaded properly
-- _Effects & Animations_ - Added `.tint()` which allows you to tint effects, tokens, and tiles
+- *Sequencer* - Fixed error caused by preload option on Sequencer Effect Player
+- *Sequencer* - Fixed error when pressing ESC in the Sequencer Layer
+- *Sequencer* - Fixed permissions not being loaded properly
+- *Effects & Animations* - Added `.tint()` which allows you to tint effects, tokens, and tiles
 
 ### Version 1.2.3
-
-- _Sequencer_ - Added granular permissions - check it out in Configure Settings -> Open Permissions Configuration
-- _Sequencer_ - Added localization support
-- _Sequencer_ - Fixed the Sequencer Player throwing an error if the layer was active while switching scene
+- *Sequencer* - Added granular permissions - check it out in Configure Settings -> Open Permissions Configuration
+- *Sequencer* - Added localization support
+- *Sequencer* - Fixed the Sequencer Player throwing an error if the layer was active while switching scene
 
 ### Version 1.2.2
-
-- _Sequencer_ - Added Stretch or Move checkbox to Sequencer Player
-- _Sequencer_ - Added Move Speed input to Sequencer Player
+- *Sequencer* - Added Stretch or Move checkbox to Sequencer Player
+- *Sequencer* - Added Move Speed input to Sequencer Player
 
 ### Version 1.2.1
-
-- _Sequencer_ - Fixed file picker being broken
+- *Sequencer* - Fixed file picker being broken
 
 ### Version 1.2.0
-
-- _Sequencer_ - Added the [Sequencer Effect Player](https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/Sequencer-Effect-Player)!
-- _Sequencer_ - Refactored the Sequencer Animation Engine, which fixes some animation funkiness
-- _Sequencer_ - Fixed the Sequencer Preloader sometimes not succeeding and getting stuck
-- _Animations_ - Removed the `.snapToSquare()` method, use `.snapToGrid()` instead
-- _Effects_ - Added `.spriteOffset()` which allows you to add an offset to the effect's sprite's location
-- _Effects_ - Added optional boolean parameters to `.randomizeMirrorX()` and `.randomizeMirrorY()`
+- *Sequencer* - Added the [Sequencer Effect Player](https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/Sequencer-Effect-Player)!
+- *Sequencer* - Refactored the Sequencer Animation Engine, which fixes some animation funkiness
+- *Sequencer* - Fixed the Sequencer Preloader sometimes not succeeding and getting stuck
+- *Animations* - Removed the `.snapToSquare()` method, use `.snapToGrid()` instead
+- *Effects* - Added `.spriteOffset()` which allows you to add an offset to the effect's sprite's location
+- *Effects* - Added optional boolean parameters to `.randomizeMirrorX()` and `.randomizeMirrorY()`
 
 ### Version 1.1.5
-
-- _Effects_ - Fixed bug that caused all effects to stay transparent after playing an effect for specific user
-- _Effects_ - Fixed bug with `.missed()` and `.reachTowards()` failing to play any effect
-- _Effects_ - Fixed all effects sharing users
+- *Effects* - Fixed bug that caused all effects to stay transparent after playing an effect for specific user
+- *Effects* - Fixed bug with `.missed()` and `.reachTowards()` failing to play any effect
+- *Effects* - Fixed all effects sharing users
 
 ### Version 1.1.4
-
-- _Sequencer_ - Fixed error in the Sequencer Preloader when pre-loading files from Database paths
-- _Effects_ - Fixed bug that caused persistent effects to end when a client connected after it was created
+- *Sequencer* - Fixed error in the Sequencer Preloader when pre-loading files from Database paths
+- *Effects* - Fixed bug that caused persistent effects to end when a client connected after it was created
 
 ### Version 1.1.3
-
-- _Sequencer_ - Added `sequencerEffectManagerReady` hook which is called when every effect has been set up on the scene that's currently loaded
-- _Sequencer_ - Added `validateEntries` method to the Sequencer Database, which is helpful for module creators to validate their asset collections to the database
-- _Sequencer_ - Added `getPathsUnder` method to the Sequencer Database, which retrieves valid collections under a certain database path
-- _Sequencer_ - Minor speed improvements to how the database retrieves files
-- _Sequencer_ - Removed the requirement for a user to be trusted to use the Database Viewer
-- _Sequencer_ - Fixed `Sequencer.EffectManager.endEffects` not throwing error when incorrect or incomplete parameters were given, and instead \_ended all effects (whoops)
-- _Effects_ - Made user-created effects that were made to be displayed only for other users also show up for GMs, though saturated and with 50% opacity. This is to ensure no player-to-player abuse would occur
-- _Effects_ - Fixed scaled tokens causing effects to not play on the correct location
-- _Effects_ - Fixed temporary effects attached to warpgate cursors no longer stays around for longer than they should
+- *Sequencer* - Added `sequencerEffectManagerReady` hook which is called when every effect has been set up on the scene that's currently loaded
+- *Sequencer* - Added `validateEntries` method to the Sequencer Database, which is helpful for module creators to validate their asset collections to the database
+- *Sequencer* - Added `getPathsUnder` method to the Sequencer Database, which retrieves valid collections under a certain database path
+- *Sequencer* - Minor speed improvements to how the database retrieves files
+- *Sequencer* - Removed the requirement for a user to be trusted to use the Database Viewer
+- *Sequencer* - Fixed `Sequencer.EffectManager.endEffects` not throwing error when incorrect or incomplete parameters were given, and instead _ended all effects (whoops)
+- *Effects* - Made user-created effects that were made to be displayed only for other users also show up for GMs, though saturated and with 50% opacity. This is to ensure no player-to-player abuse would occur
+- *Effects* - Fixed scaled tokens causing effects to not play on the correct location
+- *Effects* - Fixed temporary effects attached to warpgate cursors no longer stays around for longer than they should
 
 ### Version 1.1.2
-
-- _Sequencer_ - Removed compatibility warning regarding Perfect Vision as the module was updated to support Sequencer
-- _Sequencer_ - Added warning when trying to register database collections under a module name containing dots (as it uses dot-notated paths)
+- *Sequencer* - Removed compatibility warning regarding Perfect Vision as the module was updated to support Sequencer
+- *Sequencer* - Added warning when trying to register database collections under a module name containing dots (as it uses dot-notated paths)
 
 ### Version 1.1.1
-
-- _Sequencer_ - Removed Hyperspace sample from compendiums, as it was getting too big
-- _Sequencer_ - Added compatibility warning if user has Perfect Vision installed
-- _Sequencer_ - Added warning for Hyperspace assets that are going to be removed in a future update, and instead put into a separate module:
-  - https://foundryvtt.com/packages/nrsap by Nachtrose#9287 on Discord
-- _Sequencer_ - Prepared Sequencer for v9, it _should_ be compatible to test
-- _Effects_ - Added `.text()` which allows you to create text snippets on the canvas
-- _Effects_ - Added `.from()` which creates an effect based on the given object, effectively copying the object as an effect
-- _Effects_ - Added support for `.attachTo()` for temporary measured templates before they have been created, for use with WarpGate
-- _Effects_ - Removed warning when `.attachTo()` and `.atLocation()` are used on the same effect - `.attachTo()` always wins out
+- *Sequencer* - Removed Hyperspace sample from compendiums, as it was getting too big
+- *Sequencer* - Added compatibility warning if user has Perfect Vision installed
+- *Sequencer* - Added warning for Hyperspace assets that are going to be removed in a future update, and instead put into a separate module:
+    - https://foundryvtt.com/packages/nrsap by Nachtrose#9287 on Discord
+- *Sequencer* - Prepared Sequencer for v9, it _should_ be compatible to test
+- *Effects* - Added `.text()` which allows you to create text snippets on the canvas
+- *Effects* - Added `.from()` which creates an effect based on the given object, effectively copying the object as an effect
+- *Effects* - Added support for `.attachTo()` for temporary measured templates before they have been created, for use with WarpGate
+- *Effects* - Removed warning when `.attachTo()` and `.atLocation()` are used on the same effect - `.attachTo()` always wins out
 
 ### Version 1.1.0
-
-- _Sequencer_ - Added hooks:
-  - `createSequencerSequence`
-  - `endedSequencerSequence`
-  - Effects:
-    - `preCreateSequencerEffect` - Provides the effect's data
-    - `createSequencerEffect` - Provides the effect's data
-    - `endedSequencerEffect` - Provides the effect's data
-  - Sounds:
-    - `preCreateSequencerSound` - Provides the sound's data
-    - `createSequencerSound` - Provides the sound's data
-    - `endedSequencerSound` - Provides the sound's data
-- _Sequencer_ - Hook for `sequencer.ready` is becoming deprecated in favor for `sequencerReady`
-- _Sequencer_ - Vastly improved the speed of the Database Viewer (thanks to Naito#1235 on discord!)
-- _Effects_ - Added screen space layer for UI effects!
-  - Added `.screenSpace()` which causes the effect to be played on the screen rather than in the game canvas
-  - Added `.screenSpaceAnchor()` which causes the effect to anchor itself to a side on the screen space layer
-  - Added `.screenSpacePosition()`, pretty straightforward what this does, sets the position of the effect in screen space
-  - Added `.screenSpaceScale()` which can help you stretch and fit the effect to the screen, even on different screen sizes
-- _Effects_ - Added `.spriteAnchor()` which controls the effect's core anchor point within its container (defaults to 0.5 on X and Y)
-- _Effects_ - Added support on `.atLocation()` for a secondary options object, which currently accepts:
-  - `cacheLocation: boolean` - causes the given object's location to be cached immediately rather than retrieved during the Sequence's runtime
-- _Effects_ - Added `.snapToGrid()` which snaps the effect to the given location's closest grid section
-- _Effects_ - Added `.scaleToObject()` which scales the effect to the bounds of the object, with an optional scalar on top of that
-- _Effects_ - Added `.zeroSpriteRotation()` which causes an effect's sprite to remain un-rotated when its container rotates in animations
-- _Effects_ - Tweaked `.size()` to also accept only one of height or width, the other will be automatically resized to keep the effect's ratio
-- _Effects_ - Fixed `.persist()`ing effects with an end duration that doesn't loop would not properly stop at its end duration
-- _Effects_ - Improved look of transparent .webm files
-- _Animations_ - Renamed `.snapToSquare()` method to `.snapToGrid()` - the old method will be fully removed in 1.2.0
-- _Foundry_ - Added libwrapper patch for .webm transparency not playing correctly in Foundry
-- _Sequencer_ - Updated some sample macros
-- _Sequencer_ - The `SequencerDatabase` accessor has been removed, and is now accessible with `Sequencer.Database`
-- _Sequencer_ - The `SequencerDatabaseViewer` accessor has been removed, and is now accessible with `Sequencer.DatabaseViewer`
-- _Sequencer_ - The `SequencerPreloader` accessor is deprecated, and is now accessible with `Sequencer.Preloader`
+- *Sequencer* - Added hooks:
+    - `createSequencerSequence`
+    - `endedSequencerSequence`
+    - Effects:
+        - `preCreateSequencerEffect` - Provides the effect's data
+        - `createSequencerEffect` - Provides the effect's data
+        - `endedSequencerEffect` - Provides the effect's data
+    - Sounds:
+        - `preCreateSequencerSound` - Provides the sound's data
+        - `createSequencerSound` - Provides the sound's data
+        - `endedSequencerSound` - Provides the sound's data
+- *Sequencer* - Hook for `sequencer.ready` is becoming deprecated in favor for `sequencerReady`
+- *Sequencer* - Vastly improved the speed of the Database Viewer (thanks to Naito#1235 on discord!)
+- *Effects* - Added screen space layer for UI effects!
+    - Added `.screenSpace()` which causes the effect to be played on the screen rather than in the game canvas
+    - Added `.screenSpaceAnchor()` which causes the effect to anchor itself to a side on the screen space layer
+    - Added `.screenSpacePosition()`, pretty straightforward what this does, sets the position of the effect in screen space
+    - Added `.screenSpaceScale()` which can help you stretch and fit the effect to the screen, even on different screen sizes
+- *Effects* - Added `.spriteAnchor()` which controls the effect's core anchor point within its container (defaults to 0.5 on X and Y)
+- *Effects* - Added support on `.atLocation()` for a secondary options object, which currently accepts:
+    - `cacheLocation: boolean` - causes the given object's location to be cached immediately rather than retrieved during the Sequence's runtime
+- *Effects* - Added `.snapToGrid()` which snaps the effect to the given location's closest grid section
+- *Effects* - Added `.scaleToObject()` which scales the effect to the bounds of the object, with an optional scalar on top of that
+- *Effects* - Added `.zeroSpriteRotation()` which causes an effect's sprite to remain un-rotated when its container rotates in animations
+- *Effects* - Tweaked `.size()` to also accept only one of height or width, the other will be automatically resized to keep the effect's ratio
+- *Effects* - Fixed `.persist()`ing effects with an end duration that doesn't loop would not properly stop at its end duration
+- *Effects* - Improved look of transparent .webm files
+- *Animations* - Renamed `.snapToSquare()` method to `.snapToGrid()` - the old method will be fully removed in 1.2.0
+- *Foundry* - Added libwrapper patch for .webm transparency not playing correctly in Foundry
+- *Sequencer* - Updated some sample macros
+- *Sequencer* - The `SequencerDatabase` accessor has been removed, and is now accessible with `Sequencer.Database`
+- *Sequencer* - The `SequencerDatabaseViewer` accessor has been removed, and is now accessible with `Sequencer.DatabaseViewer`
+- *Sequencer* - The `SequencerPreloader` accessor is deprecated, and is now accessible with `Sequencer.Preloader`
 
 ### Version 1.0.3
-
-- _Sequencer_ - Added animated space backgrounds (thanks to Keirsti on the Foundry VTT discord server)
-- _Sequencer_ - Fixed Hyperspace macro placing the hyperspace intro and out incorrectly
+- *Sequencer* - Added animated space backgrounds (thanks to Keirsti on the Foundry VTT discord server)
+- *Sequencer* - Fixed Hyperspace macro placing the hyperspace intro and out incorrectly
 
 ### Version 1.0.2 Hotfix
-
-- _Sequencer_ - Changed Effect Viewer icon to something less controversial
+- *Sequencer* - Changed Effect Viewer icon to something less controversial
 
 ### Version 1.0.1
-
-- _Sequencer_ - Renamed `.sequence()` method on Sequences to `.addSequence()` due to internal code conflicts
-- _Effects_ - Added `.filter()` - was technically added in 1.0.0, but was left undocumented
-- _Effects_ - Fixed `.size()` being scaled to account for grid size differences - it should now set the exact width/height in pixels
+- *Sequencer* - Renamed `.sequence()` method on Sequences to `.addSequence()` due to internal code conflicts
+- *Effects* - Added `.filter()` - was technically added in 1.0.0, but was left undocumented
+- *Effects* - Fixed `.size()` being scaled to account for grid size differences - it should now set the exact width/height in pixels
 
 ### Version 1.0.0
-
-- _Sequencer_ - Added recent Sequencer tools to the menu in the top left - you can disable these in the module settings
-- _Sequencer_ - Added `Sequencer.EffectManager` to manage persistent effects - [read more here](https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/Sequencer-Effect-Manager)
-- _Sequencer_ - Added the ability for you to implement your own Sequencer functions - [read more here](https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/Sequencer-Section-Manager)
-- _Sequencer_ - `SequencerDatabase` is deprecated, and is now accessible with `Sequencer.Database` - 1.1.0 will remove the old path entirely
-- _Sequencer_ - `SequencerDatabaseViewer` is deprecated, and is now accessible with `Sequencer.DatabaseViewer` - 1.1.0 will remove the old path entirely
-- _Sequencer_ - `SequencerPreloader` is deprecated, and is now accessible with `Sequencer.Preloader` - 1.1.0 will remove the old path entirely
-- _Sequencer_ - Fixed Documents sometimes not properly resolving to their PlaceableObject
-- _Sequencer_ - Fixed settings not being client side - whoops
-- _Effects_ - Added `.attachTo()` which causes the effect to be attached to a given object
-- _Effects_ - Added `.persist()` which causes the effect to become permanent on the canvas until removed
-- _Effects_ - Added `.extraEndDuration()` which allows `.persist()`-ed effects to stick around for a bit longer instead of end immediately
-- _Effects_ - Tweaked `.missed()` to hit an area only facing the origin of the effect, if it had an origin and target
-- _Effects & Sounds_ - Added support for wildcard paths, like `modules/jb2a_patreon/Library/1st_Level/Bardic_Inspiration/BardicInspiration_01_*_400x400.webm`
+- *Sequencer* - Added recent Sequencer tools to the menu in the top left - you can disable these in the module settings
+- *Sequencer* - Added `Sequencer.EffectManager` to manage persistent effects - [read more here](https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/Sequencer-Effect-Manager)
+- *Sequencer* - Added the ability for you to implement your own Sequencer functions - [read more here](https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/Sequencer-Section-Manager)
+- *Sequencer* - `SequencerDatabase` is deprecated, and is now accessible with `Sequencer.Database` - 1.1.0 will remove the old path entirely
+- *Sequencer* - `SequencerDatabaseViewer` is deprecated, and is now accessible with `Sequencer.DatabaseViewer` - 1.1.0 will remove the old path entirely
+- *Sequencer* - `SequencerPreloader` is deprecated, and is now accessible with `Sequencer.Preloader` - 1.1.0 will remove the old path entirely
+- *Sequencer* - Fixed Documents sometimes not properly resolving to their PlaceableObject
+- *Sequencer* - Fixed settings not being client side - whoops
+- *Effects* - Added `.attachTo()` which causes the effect to be attached to a given object
+- *Effects* - Added `.persist()` which causes the effect to become permanent on the canvas until removed
+- *Effects* - Added `.extraEndDuration()` which allows `.persist()`-ed effects to stick around for a bit longer instead of end immediately
+- *Effects* - Tweaked `.missed()` to hit an area only facing the origin of the effect, if it had an origin and target
+- *Effects & Sounds* - Added support for wildcard paths, like `modules/jb2a_patreon/Library/1st_Level/Bardic_Inspiration/BardicInspiration_01_*_400x400.webm`
 
 ### Version 0.6.12
-
-- _Sequencer_ - Fixed an issue where the preloader would sometimes fail to preload
-- _Effects_ - Fixed effects not playing on hex grids
+- *Sequencer* - Fixed an issue where the preloader would sometimes fail to preload
+- *Effects* - Fixed effects not playing on hex grids
 
 ### Version 0.6.11 Hotfix
-
-- _Effects_ - Fixed range-finding effects sometimes not picking the right distance
+- *Effects* - Fixed range-finding effects sometimes not picking the right distance
 
 ### Version 0.6.10
-
-- _Sequencer_ - Improved the search speed of the Database Viewer
-- _Sequencer_ - Fixed previewing static images through the Database Viewer
-- _Sequencer_ - Fixed bugs that caused the Database to sometimes fail registering new files
-- _Effects_ - Fixed issue where `.delay()` would incorrectly contribute towards the effect's `.waitUntilFinished()` duration
+- *Sequencer* - Improved the search speed of the Database Viewer
+- *Sequencer* - Fixed previewing static images through the Database Viewer
+- *Sequencer* - Fixed bugs that caused the Database to sometimes fail registering new files
+- *Effects* - Fixed issue where `.delay()` would incorrectly contribute towards the effect's `.waitUntilFinished()` duration
 
 ### Version 0.6.9 Hotfix
-
-- _Sequencer_ - Fixed the database sometimes failing to get the correct file
+- *Sequencer* - Fixed the database sometimes failing to get the correct file
 
 ### Version 0.6.8 Hotfix
-
-- _Sequencer_ - Fixed database not correctly finding range-based effects
+- *Sequencer* - Fixed database not correctly finding range-based effects
 
 ### Version 0.6.7
-
-- _Effects & Sounds_ - Fixed `.locally()` and `.forUsers()` sometimes erroneously remembering users between different effects & sounds
-- _Effects_ - Fixed `.scaleIn()` would not take a custom `.size()` into account
-- _Effects_ - Fixed static images sometimes not playing due to duration being set to 0ms
+- *Effects & Sounds* - Fixed `.locally()` and `.forUsers()` sometimes erroneously remembering users between different effects & sounds
+- *Effects* - Fixed `.scaleIn()` would not take a custom `.size()` into account
+- *Effects* - Fixed static images sometimes not playing due to duration being set to 0ms
 
 ### Version 0.6.6
-
-- _Sequencer_ - Added support for preloading files based on database paths
-- _Effects & Sounds_ - Added `.locally()` and `.forUsers()`, which allow you to control which users will have the effect and sounds played for them
-- _Effects_ - Improved positional handling of Tiles and TileDocuments
+- *Sequencer* - Added support for preloading files based on database paths
+- *Effects & Sounds* - Added `.locally()` and `.forUsers()`, which allow you to control which users will have the effect and sounds played for them
+- *Effects* - Improved positional handling of Tiles and TileDocuments
 
 ### Version 0.6.5
-
-- _Sequencer_ - Updated Sequencer Database Viewer layout to be more user friendly
-- _Effects_ - Fixed bug with templates and raw positions not being respected
+- *Sequencer* - Updated Sequencer Database Viewer layout to be more user friendly
+- *Effects* - Fixed bug with templates and raw positions not being respected
 
 ### Version 0.6.4
-
-- _Sequencer_ - Added Sequencer Database Viewer to the module settings, it allows you to preview effects and copy any files registered with Sequencer by other modules
-- _Sequencer_ - Added client-side settings for users to be able to turn off effects and sounds being played locally
-- _Effects & Sounds_ - Fixed effects and sounds playing on scenes they did not originate from
-- _Effects_ - Added `.size()`, which sets the width and height of the effect in pixels
-- _Effects_ - Added `rotate` option to `.moveTowards()`, which defaults to true. If set to false, the effect will not rotate towards the end location.
-- _Effects_ - Fixed duration of effects using `.moveTowards()` not being calculated correctly
-- _Effects_ - Fixed static image effects' durations also not being calculated correctly
+- *Sequencer* - Added Sequencer Database Viewer to the module settings, it allows you to preview effects and copy any files registered with Sequencer by other modules
+- *Sequencer* - Added client-side settings for users to be able to turn off effects and sounds being played locally
+- *Effects & Sounds* - Fixed effects and sounds playing on scenes they did not originate from
+- *Effects* - Added `.size()`, which sets the width and height of the effect in pixels
+- *Effects* - Added `rotate` option to `.moveTowards()`, which defaults to true. If set to false, the effect will not rotate towards the end location.
+- *Effects* - Fixed duration of effects using `.moveTowards()` not being calculated correctly
+- *Effects* - Fixed static image effects' durations also not being calculated correctly
 
 ### Version 0.6.3 Hotfix
-
-- _Effects_ - Fixed effects failing to play static images
+- *Effects* - Fixed effects failing to play static images
 
 ### Version 0.6.2
-
-- _Sequencer_ - Further small fixes to how the database registers files
+- *Sequencer* - Further small fixes to how the database registers files
 
 ### Version 0.6.1
-
-- _Sequencer_ - Removed the need for `.playIf()` to have to be given a function or a boolean
-- _Sequencer_ - Fixed issues with the database when files were listed in arrays
+- *Sequencer* - Removed the need for `.playIf()` to have to be given a function or a boolean
+- *Sequencer* - Fixed issues with the database when files were listed in arrays
 
 ### Version 0.6.0
-
 **Breaking:**
-
-- _Effects_ - <img src="images/siren.gif" width="12px" height="12px" alt="Siren"> `.JB2A()` has been altered to set the gridsize to 200, as it was previously set to 100 - this will halve the size all JB2A on-the-spot effects, sorry! <img src="images/siren.gif" width="12px" height="12px" alt="Siren">
+- *Effects* - <img src="images/siren.gif" width="12px" height="12px" alt="Siren"> `.JB2A()` has been altered to set the gridsize to 200, as it was previously set to 100 - this will halve the size all JB2A on-the-spot effects, sorry! <img src="images/siren.gif" width="12px" height="12px" alt="Siren">
 
 **Additions:**
-
-- _Sequencer_ - Added `SequencerPreloader` - you can now preload images, effects, and sounds for your players, read more on the [docs](https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/Sequencer-Preloader)
-- _Sequencer_ - Added support for templates and time ranges in database structure, more info on the [docs](https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/How-to:-Sequencer-Database)
-- _Effects_ - Added support for static images such as webp, pngs, jpgs, etc
-- _Effects & Sounds_ - Added `.startTime()`, `.startTimePerc()`, `.endTime()`, `.endTimePerc()`, and `.timeRange()`, more info on the [docs](https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/Effects#start-time)
-- _Sounds_ - Added `.addOverride()`, `.baseFolder()`, and `.setMustache()` support to sounds
+- *Sequencer* - Added `SequencerPreloader` - you can now preload images, effects, and sounds for your players, read more on the [docs](https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/Sequencer-Preloader)
+- *Sequencer* - Added support for templates and time ranges in database structure, more info on the [docs](https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/How-to:-Sequencer-Database)
+- *Effects* - Added support for static images such as webp, pngs, jpgs, etc
+- *Effects & Sounds* - Added `.startTime()`, `.startTimePerc()`, `.endTime()`, `.endTimePerc()`, and `.timeRange()`, more info on the [docs](https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/Effects#start-time)
+- *Sounds* - Added `.addOverride()`, `.baseFolder()`, and `.setMustache()` support to sounds
 
 **Updates & Fixes:**
-
-- _Sequencer_ - `.play()` now reliably resolves its promise at the end of the entire sequence
-- _Effects_ - _Vastly_ improved effect caching and loading speed of effects and sounds
-- _Effects_ - Improved object position handling slightly when providing non-foundry class objects to `.atLocation()` and alike
-- _Effects_ - Generally improved compatibility with `TokenDocument` and Foundry D&D 5E documents when getting their positions
+- *Sequencer* - `.play()` now reliably resolves its promise at the end of the entire sequence
+- *Effects* - *Vastly* improved effect caching and loading speed of effects and sounds
+- *Effects* - Improved object position handling slightly when providing non-foundry class objects to `.atLocation()` and alike
+- *Effects* - Generally improved compatibility with `TokenDocument` and Foundry D&D 5E documents when getting their positions
 
 ### Version 0.5.9
-
-- _Effects_ - Added `.addPostOverride()` as an alternative to `.addOverride()`, which executes at the end of the effect data sanitation
-- _Effects_ - Fixed `.gridSize()`, `.startPoint()`, and `.endPoint()` not being respected and being overridden by internal logic
+- *Effects* - Added `.addPostOverride()` as an alternative to `.addOverride()`, which executes at the end of the effect data sanitation
+- *Effects* - Fixed `.gridSize()`, `.startPoint()`, and `.endPoint()` not being respected and being overridden by internal logic
 
 ### Version 0.5.8 Hotfix
-
-- _Macros_ - Fixed macros throwing error when playing sequence
+- *Macros* - Fixed macros throwing error when playing sequence
 
 ### Version 0.5.7
-
-- _Effects_ - Fixed templates sometimes not being found
-- _Effects_ - Re-added backwards compatibility with old macros that still use `data.distance` in overrides
+- *Effects* - Fixed templates sometimes not being found
+- *Effects* - Re-added backwards compatibility with old macros that still use `data.distance` in overrides
 
 ### Version 0.5.6
-
-- _Sequencer_ - Added alpha version of the Sequencer Database Viewer
-- _Effects_ - Added `.randomOffset()` which can add a random offset similar to `.missed()`, but _within_ the bounds of the target token / tile / other. Check out the docs!
-- _Effects_ - Fixed `.waitUntilFinished()` not being respected
-- _Effects_ - Fixed `.offset()` throwing an error about a missing function
-- _Effects_ - Fixed `.repeats()` throwing an error, because the entire function went missing in the last update >.>
+- *Sequencer* - Added alpha version of the Sequencer Database Viewer
+- *Effects* - Added `.randomOffset()` which can add a random offset similar to `.missed()`, but *within* the bounds of the target token / tile / other. Check out the docs!
+- *Effects* - Fixed `.waitUntilFinished()` not being respected
+- *Effects* - Fixed `.offset()` throwing an error about a missing function
+- *Effects* - Fixed `.repeats()` throwing an error, because the entire function went missing in the last update >.>
 
 ### Version 0.5.5 Hotfix
-
-- _Effects_ - Fixed effects sometimes not playing
+- *Effects* - Fixed effects sometimes not playing
 
 ### Version 0.5.4 Hotfix
-
-- _Effects_ - Fixed melee attacks not picking the right JB2A template
+- *Effects* - Fixed melee attacks not picking the right JB2A template
 
 ### Version 0.5.3
-
-- _Sequencer_ - Added sound to the Hyperspeed Sample thanks to the wonderful AurelTristen over at [HellScape Tabletop Assets](https://www.patreon.com/HellScapeAssets) (even though they're not specifically focused on sound effects)
-- _Effects_ - Fixed major issue with JB2A templates, causing effects to pick the wrong ranged attacks & other shenanigans
-- _Effects_ - Fixed effect scale inconsistencies across scenes with different grid sizes
+- *Sequencer* - Added sound to the Hyperspeed Sample thanks to the wonderful AurelTristen over at [HellScape Tabletop Assets](https://www.patreon.com/HellScapeAssets) (even though they're not specifically focused on sound effects)
+- *Effects* - Fixed major issue with JB2A templates, causing effects to pick the wrong ranged attacks & other shenanigans
+- *Effects* - Fixed effect scale inconsistencies across scenes with different grid sizes
 
 ### Version 0.5.2
-
-- _Sequencer_ - <img src="images/siren.gif" width="12px" height="12px" alt="Siren"> Removed support for Foundry Version 0.7.x <img src="images/siren.gif" width="12px" height="12px" alt="Siren">
-- _Sequencer_ - Refactored animations into a dedicated animation engine
-- _Effects_ - Added support for static image effects (.jpeg, .png, etc)
-- _Effects_ - Fixed grid size sometimes not being taken into account when playing effects with `.reachTowards()`
-- _Sounds_ - Vastly improved and fixed sound implementation, big thanks to ghost#2000!
-- _Sounds_ - <img src="images/siren.gif" width="12px" height="12px" alt="Siren"> Removed support for `.fadeIn()` and `.fadeOut()` in Sounds <img src="images/siren.gif" width="12px" height="12px" alt="Siren">
+- *Sequencer* - <img src="images/siren.gif" width="12px" height="12px" alt="Siren"> Removed support for Foundry Version 0.7.x <img src="images/siren.gif" width="12px" height="12px" alt="Siren">
+- *Sequencer* - Refactored animations into a dedicated animation engine
+- *Effects* - Added support for static image effects (.jpeg, .png, etc)
+- *Effects* - Fixed grid size sometimes not being taken into account when playing effects with `.reachTowards()`
+- *Sounds* - Vastly improved and fixed sound implementation, big thanks to ghost#2000!
+- *Sounds* - <img src="images/siren.gif" width="12px" height="12px" alt="Siren"> Removed support for `.fadeIn()` and `.fadeOut()` in Sounds <img src="images/siren.gif" width="12px" height="12px" alt="Siren">
 
 ### Version 0.5.1
-
-- _Sequencer_ - Added two sample scenes with macros and accompanying art:
-  - An animated Oujia board made by md-mention2reply
-  - A Star Wars inspired hyperspeed scene-switching scene, effects, and macro
-- _Sequencer_ - Removed Token Ease as dependency until we can solve its conflicts with other modules
-- _Effects_ - Fixed effects not auto-centering on tokens
-- _Effects_ - Fixed effects not finding the proper location when a previous effect's `.name()` was given
-- _Animations_ - Fixed `.rotate()`, `.opacity()`, and `.volume()`, now they work even without having to use their respective in/out functions
+- *Sequencer* - Added two sample scenes with macros and accompanying art:
+    - An animated Oujia board made by md-mention2reply
+    - A Star Wars inspired hyperspeed scene-switching scene, effects, and macro
+- *Sequencer* - Removed Token Ease as dependency until we can solve its conflicts with other modules
+- *Effects* - Fixed effects not auto-centering on tokens
+- *Effects* - Fixed effects not finding the proper location when a previous effect's `.name()` was given
+- *Animations* - Fixed `.rotate()`, `.opacity()`, and `.volume()`, now they work even without having to use their respective in/out functions
 
 ### Version 0.5.0
-
-- _Sequencer_ - Module now depends on [Token Ease](https://github.com/fantasycalendar/FoundryVTT-TokenEase)
-- _Sequencer_ - Added the Sequencer Database to help content creators! Read more on the [database documentation](https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/Sequencer-Database) how to use it!
-- _Effects & Sounds_ - Added support for database collections to the `.file()` method - more info can be found in the [docs](https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/Effects#file)
-- _Animations, Effects & Sounds_ - Added the following functions:
-  - `.audioVolume()`
-  - `.fadeInAudio()`
-  - `.fadeOutAudio()`
-- _Effects_ - Added support for delays on these methods (e.g. a delay of -500 means it will finish 500ms before the end of the duration):
-  - `.rotateOut()`
-  - `.fadeOut()`
-  - `.scaleOut()`
-  - `.fadeOutAudio()`
-- _Animations_ - Fixed `.rotateTowards()` to properly rotate towards the target without having to add an offset to properly line them up
-- _Effects_ - Made effects more intelligent when determining locations when given partial object data with `id` collections
-- _Effects_ - Fixed issues surrounding delays and fades
-- _Sounds_ - <img src="images/siren.gif" width="12px" height="12px" alt="Siren"> `.fadeIn()` and `.fadeOut()` will become deprecated in a future version, please switch to `.fadeInAudio()` and `.fadeOutAudio()` <img src="images/siren.gif" width="12px" height="12px" alt="Siren">
+- *Sequencer* - Module now depends on [Token Ease](https://github.com/fantasycalendar/FoundryVTT-TokenEase)
+- *Sequencer* - Added the Sequencer Database to help content creators! Read more on the [database documentation](https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/Sequencer-Database) how to use it!
+- *Effects & Sounds* - Added support for database collections to the `.file()` method - more info can be found in the [docs](https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/Effects#file)
+- *Animations, Effects & Sounds* - Added the following functions:
+    - `.audioVolume()`
+    - `.fadeInAudio()`
+    - `.fadeOutAudio()`
+- *Effects* - Added support for delays on these methods (e.g. a delay of -500 means it will finish 500ms before the end of the duration):
+    - `.rotateOut()`
+    - `.fadeOut()`
+    - `.scaleOut()`
+    - `.fadeOutAudio()`
+- *Animations* - Fixed `.rotateTowards()` to properly rotate towards the target without having to add an offset to properly line them up
+- *Effects* - Made effects more intelligent when determining locations when given partial object data with `id` collections
+- *Effects* - Fixed issues surrounding delays and fades
+- *Sounds* - <img src="images/siren.gif" width="12px" height="12px" alt="Siren"> `.fadeIn()` and `.fadeOut()` will become deprecated in a future version, please switch to `.fadeInAudio()` and `.fadeOutAudio()` <img src="images/siren.gif" width="12px" height="12px" alt="Siren">
 
 ### Version 0.4.6 Hotfix
-
-- _Effects_ - Fixed effects not playing on tokens on 0.7.10 and below
+- *Effects* - Fixed effects not playing on tokens on 0.7.10 and below
 
 ### Version 0.4.5
-
-- _Effects_ - Added `.offset()` so that you can offset the effect - an optional parameter allows you to offset in local or canvas space
-- _Animations_ - Added `.snapToSquare()`, which causes the given object to be snapped to the square it is moving or teleported towards
-- _Animations_ - Fixed `.rotateIn()` and `.rotateOut()` not properly calculating rotation
-- _Animations_ - Adjusted `.rotateTowards()` to instead consider the target position as the rotation origin, rather than the object's current position
+- *Effects* - Added `.offset()` so that you can offset the effect - an optional parameter allows you to offset in local or canvas space
+- *Animations* - Added `.snapToSquare()`, which causes the given object to be snapped to the square it is moving or teleported towards
+- *Animations* - Fixed `.rotateIn()` and `.rotateOut()` not properly calculating rotation
+- *Animations* - Adjusted `.rotateTowards()` to instead consider the target position as the rotation origin, rather than the object's current position
 
 ### Version 0.4.4
-
-- _Animations_ - Added `.animation()` section - animate tokens and tiles! Check out the [documentation](https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/Animations) how to use it!
-- _Effects_ - Added official support for tiles in `.atLocation()`, `.moveTowards()`, etc
-- _Effects_ - Tweaked how effects get locations when dealing with raw template data
-- _Sequencer_ - Added `.sequence()` so you can combine multiple sequences into one
-- _Sequencer_ - Updated all sample macros to 0.8.x conventions
+- *Animations* - Added `.animation()` section - animate tokens and tiles! Check out the [documentation](https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/Animations) how to use it!
+- *Effects* - Added official support for tiles in `.atLocation()`, `.moveTowards()`, etc
+- *Effects* - Tweaked how effects get locations when dealing with raw template data
+- *Sequencer* - Added `.sequence()` so you can combine multiple sequences into one
+- *Sequencer* - Updated all sample macros to 0.8.x conventions
 
 ### Version 0.4.3 Minor Fixes
-
-- _Effects_ - Removed error catch in `.file()` when providing it with something else than string or array
-- _Effects_ - Fixed `.belowTokens()` and `.belowTiles()` throwing errors if no boolean was provided
+- *Effects* - Removed error catch in `.file()` when providing it with something else than string or array
+- *Effects* - Fixed `.belowTokens()` and `.belowTiles()` throwing errors if no boolean was provided
 
 ### Version 0.4.2 Hotfix
-
-- _Effects_ - Added `.rotate()` which adds an offset to the effect's rotation
-- _Effects_ - Fixed `.moveTowards()` not respecting given easing
+- *Effects* - Added `.rotate()` which adds an offset to the effect's rotation
+- *Effects* - Fixed `.moveTowards()` not respecting given easing
 
 ### Version 0.4.1
-
-- _Sequencer_ - <img src="images/siren.gif" width="12px" height="12px" alt="Siren"> **Breaking Changes**: Removed deprecated `.then()` method <img src="images/siren.gif" width="12px" height="12px" alt="Siren">
-- _Sequencer_ - Tweaked `.play()` to now return a promise
-- _Sequencer_ - Reworked module class structure
-- _Sequencer_ - Added debug setting
+- *Sequencer* - <img src="images/siren.gif" width="12px" height="12px" alt="Siren"> **Breaking Changes**: Removed deprecated `.then()` method <img src="images/siren.gif" width="12px" height="12px" alt="Siren">
+- *Sequencer* - Tweaked `.play()` to now return a promise
+- *Sequencer* - Reworked module class structure
+- *Sequencer* - Added debug setting
 
 ### Version 0.4.0
-
-- _Sequencer_ - Renamed `.then()` to `.thenDo()` due to JavaScript reasons — <img src="images/siren.gif" width="12px" height="12px" alt="Siren"> `.then()` will be removed in 0.4.1 <img src="images/siren.gif" width="12px" height="12px" alt="Siren">
-- _Sequencer_ - Removed the requirement to pass `true` as a second argument to `.then()` (now `.thenDo()`) if the function was async, it will now wait for it to finish if it is an `async function`
-- _Effects_ - Added `.mirrorX()` and `.mirrorY()` to mirror the effect on that axis
-- _Effects_ - Improved `.JB2A()` to better handle melee weapon attacks
-- _Effects_ - Tweaked `.belowTiles()` and `.belowTokens()` to accept an optional boolean parameter whether the effect should play behind the respective element
-- _Effects_ - Tweaked effects to assume that .webms have a base 100px internal grid for size consistency
+- *Sequencer* - Renamed `.then()` to `.thenDo()` due to JavaScript reasons — <img src="images/siren.gif" width="12px" height="12px" alt="Siren"> `.then()` will be removed in 0.4.1 <img src="images/siren.gif" width="12px" height="12px" alt="Siren">
+- *Sequencer* - Removed the requirement to pass `true` as a second argument to `.then()` (now `.thenDo()`) if the function was async, it will now wait for it to finish if it is an `async function`
+- *Effects* - Added `.mirrorX()` and `.mirrorY()` to mirror the effect on that axis
+- *Effects* - Improved `.JB2A()` to better handle melee weapon attacks
+- *Effects* - Tweaked `.belowTiles()` and `.belowTokens()` to accept an optional boolean parameter whether the effect should play behind the respective element
+- *Effects* - Tweaked effects to assume that .webms have a base 100px internal grid for size consistency
 
 ### Version 0.3.13 Hotfix
-
-- _Effects_ - Fixed ANOTHER bug with `.belowTiles()` sometimes not playing below tiles
+- *Effects* - Fixed ANOTHER bug with `.belowTiles()` sometimes not playing below tiles
 
 ### Version 0.3.12
-
-- _Effects_ - Added `.opacity()` which controls the alpha of the effect being played
-- _Effects_ - Fixed bug with `.belowTiles()` sometimes not playing below tiles
+- *Effects* - Added `.opacity()` which controls the alpha of the effect being played
+- *Effects* - Fixed bug with `.belowTiles()` sometimes not playing below tiles
 
 ### Version 0.3.11
-
-- _Effects_ - Added `.belowTiles()` to play effects below tiles
-- _Effects_ - Implemented better order handling - the effects created first will always be on top, each subsequent effect will be played below the previous
-- _Effects_ - Added `.zIndex()` for you to have direct control over the order of effects
-- _Effects & Sounds_ - Added `.duration()` which can override the duration of an effect or sound
-- _Effects & Sounds_ - Tweaked `.waitUntilFinished()` to accept a single number parameter as a delay or to end the effect or sound earlier - read more in the [documentation](https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki#wait-until-finished)
-- _Sounds_ - Added support for `.fadeIn()` and `.fadeOut()` - easing sadly doesn't work for sounds yet
+- *Effects* - Added `.belowTiles()` to play effects below tiles
+- *Effects* - Implemented better order handling - the effects created first will always be on top, each subsequent effect will be played below the previous
+- *Effects* - Added `.zIndex()` for you to have direct control over the order of effects
+- *Effects & Sounds* - Added `.duration()` which can override the duration of an effect or sound
+- *Effects & Sounds* - Tweaked `.waitUntilFinished()` to accept a single number parameter as a delay or to end the effect or sound earlier - read more in the [documentation](https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki#wait-until-finished)
+- *Sounds* - Added support for `.fadeIn()` and `.fadeOut()` - easing sadly doesn't work for sounds yet
 
 ### Version 0.3.10
-
-- _Sequencer_ - Added macro pack containing examples of Sequencer usages
-- _Effects_ - Added the following animated functions:
-  - `.scaleIn()`
-  - `.scaleOut()`
-  - `.rotateIn()`
-  - `.rotateOut()`
-  - All of these can utilize any of the easings listed here: https://easings.net/
-  - Read the [documentation](https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/Effects#scale-in) how to use these
-- _Effects_ - Added better error reporting when something goes wrong in the sequence
-- _Effects_ - Fixed bug with scale sometimes overriding `.reachTowards()`
+- *Sequencer* - Added macro pack containing examples of Sequencer usages
+- *Effects* - Added the following animated functions:
+    - `.scaleIn()`
+    - `.scaleOut()`
+    - `.rotateIn()`
+    - `.rotateOut()`
+    - All of these can utilize any of the easings listed here: https://easings.net/
+    - Read the [documentation](https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki/Effects#scale-in) how to use these
+- *Effects* - Added better error reporting when something goes wrong in the sequence
+- *Effects* - Fixed bug with scale sometimes overriding `.reachTowards()`
 
 ### Version 0.3.9
-
-- _Effects_ - Added `.belowTokens()` so you can now play effects, well, below tokens
-- _Effects_ - Fixed effects not replicating properly (AGAIN)
-- _Effects_ - Fixed effects not being able to use `.name()`d effects if they didn't miss - now any effect can be named and be used in future effects
+- *Effects* - Added `.belowTokens()` so you can now play effects, well, below tokens
+- *Effects* - Fixed effects not replicating properly (AGAIN)
+- *Effects* - Fixed effects not being able to use `.name()`d effects if they didn't miss - now any effect can be named and be used in future effects
 
 ### Version 0.3.8 Hotfix
-
-- _Effects_ - Fixed effects that were supposed to be once-off instead looping
+- *Effects* - Fixed effects that were supposed to be once-off instead looping
 
 ### Version 0.3.7
-
-- _Effects_ - Added `.moveTowards()` and `.moveSpeed()` for missile-like behavior
-- _Effects_ - Tweaked the way the effects layer is applied to the canvas' layers
-- _Effects_ - Fixed major issue with the way effects that were using `.missed()` and `.name()` were cached
-- _Sequencer_ - Removed stray debug code
+- *Effects* - Added `.moveTowards()` and `.moveSpeed()` for missile-like behavior
+- *Effects* - Tweaked the way the effects layer is applied to the canvas' layers
+- *Effects* - Fixed major issue with the way effects that were using `.missed()` and `.name()` were cached
+- *Sequencer* - Removed stray debug code
 
 ### Version 0.3.6
-
-- _Effects_ - Added `.fadeIn()` and `.fadeOut()` - you can now make your effects look slightly nicer!
-- _Effects_ - Added support for cone and line templates with `.reachTowards()` and `.rotateTowards()` - it now reaches towards the end point of the template
-- _Effects_ - Added `.name()` to effects - this will cause the effect's position to be stored and can then be used with `.atLocation()`, `.reachTowards()`, and `.rotateTowards()` to refer to previous effects' locations
-  - Example: naming an impact effect with `.name("hit_location")` and making it miss with `.missed()`, and then have a subsequent effect use `.rotateTowards("hit_location")` to rotate towards the previous effect's calculated location
-- _Effects_ - Fixed `.scale()` bug that caused it to not properly set the scale and then cause an error upon calling `.play()`
-- _Effects_ - Removed `.moves()` for future implementation
-- _Sequencer_ - Tweaked `.async()` and `.waitUntilFinished()` handling
-  - They now act the same on effect and sounds that only play once, but if it `.repeats()`, `.async()` causes the effect or sound to wait between each repetition, `.waitUntilFinished()` causes the sequencer to wait until the effect or sound has finished executing all of its repetitions, which may or may not wait for each effect or sound to play with `.async()`
-- _Sequencer_ - Calling `.play()` now returns the sequence
-- _Sequencer_ - Removed `FXMaster` dependency and implemented a custom canvas layer and effects class
+- *Effects* - Added `.fadeIn()` and `.fadeOut()` - you can now make your effects look slightly nicer!
+- *Effects* - Added support for cone and line templates with `.reachTowards()` and `.rotateTowards()` - it now reaches towards the end point of the template
+- *Effects* - Added `.name()` to effects - this will cause the effect's position to be stored and can then be used with `.atLocation()`, `.reachTowards()`, and `.rotateTowards()` to refer to previous effects' locations
+    - Example: naming an impact effect with `.name("hit_location")` and making it miss with `.missed()`, and then have a subsequent effect use `.rotateTowards("hit_location")` to rotate towards the previous effect's calculated location
+- *Effects* - Fixed `.scale()` bug that caused it to not properly set the scale and then cause an error upon calling `.play()`
+- *Effects* - Removed `.moves()` for future implementation
+- *Sequencer* - Tweaked `.async()` and `.waitUntilFinished()` handling
+    - They now act the same on effect and sounds that only play once, but if it `.repeats()`, `.async()` causes the effect or sound to wait between each repetition, `.waitUntilFinished()` causes the sequencer to wait until the effect or sound has finished executing all of its repetitions, which may or may not wait for each effect or sound to play with `.async()`
+- *Sequencer* - Calling `.play()` now returns the sequence
+- *Sequencer* - Removed `FXMaster` dependency and implemented a custom canvas layer and effects class
 
 ### Version 0.3.5 Hotfix
-
-- _Sequencer_ - Fixed `.wait()` breaking due to the `.async()` and `.waitUntilFinished()` swap
+- *Sequencer* - Fixed `.wait()` breaking due to the `.async()` and `.waitUntilFinished()` swap
 
 ### Version 0.3.4 Hotfix
-
-- _Effects_ - Fixed issue that caused the wrong scale to be applied when using `.reachTowards()`
+- *Effects* - Fixed issue that caused the wrong scale to be applied when using `.reachTowards()`
 
 ### Version 0.3.3
-
-- _Effects_ - Added `.playIf()` ([docs](https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki#play-if)); this allows you to completely ignore playing an effect or sound, depending on a boolean or a function
-- _Sounds_ - Added support for `.async()` and `.waitUntilFinished()` for sounds - requires both to be `true` due to code weirdness, I'll be refactoring this in the future
-- _Effects_ - Refactored `.scale()` when it was provided with a minimum and maximum value, it now randomizes the scale of the effect when executed instead of when the method was called
-- _Effects & Sounds_ - Refactored `.file()` for both effects and sounds so that providing an array of files no longer immediately picks one from the array, but randomly picks a file each time the section is executed
-- _Effects & Sounds_ - Refactored how `.delay()` interacted with `.repeats()`, which should result in more consistent behavior
-- _Sequencer_ - Swapped the functionality of `.async()` and `.waitUntilFinished()`, and clarified in the docs
-- _Sequencer_ - Added support for random range within a `.wait()` block (like, `.wait(500, 1000)` etc)
+- *Effects* - Added `.playIf()` ([docs](https://github.com/fantasycalendar/FoundryVTT-Sequencer/wiki#play-if)); this allows you to completely ignore playing an effect or sound, depending on a boolean or a function
+- *Sounds* - Added support for `.async()` and `.waitUntilFinished()` for sounds - requires both to be `true` due to code weirdness, I'll be refactoring this in the future
+- *Effects* - Refactored `.scale()` when it was provided with a minimum and maximum value, it now randomizes the scale of the effect when executed instead of when the method was called
+- *Effects & Sounds* - Refactored `.file()` for both effects and sounds so that providing an array of files no longer immediately picks one from the array, but randomly picks a file each time the section is executed
+- *Effects & Sounds* - Refactored how `.delay()` interacted with `.repeats()`, which should result in more consistent behavior
+- *Sequencer* - Swapped the functionality of `.async()` and `.waitUntilFinished()`, and clarified in the docs
+- *Sequencer* - Added support for random range within a `.wait()` block (like, `.wait(500, 1000)` etc)
 
 ### Version 0.3.2 - 0.8.x ready!
-
-- _Effects_ - Added `.playbackRate()` to effects, you can now speed up the play rate of your effects
-- _Sequencer_ - Tweaked internal handling of `.async()` together with `.waitUntilFinished()` improved
-- _Sequencer_ - Tweaked to use `ready` instead of `init` to load module
+* *Effects* - Added `.playbackRate()` to effects, you can now speed up the play rate of your effects
+* *Sequencer* - Tweaked internal handling of `.async()` together with `.waitUntilFinished()` improved
+* *Sequencer* - Tweaked to use `ready` instead of `init` to load module
 
 ### Version 0.3.1
-
-- _Effects_ - Refactored `.randomizeMirror()` into `.randomizeMirrorX()` and `.randomizeMirrorY()`
-- _Effects_ - Refactored scaling algorithm for `.reachTowards()`
-- _Sequencer_ - Added support for random `.wait()` interval
+- *Effects* - Refactored `.randomizeMirror()` into `.randomizeMirrorX()` and `.randomizeMirrorY()`
+- *Effects* - Refactored scaling algorithm for `.reachTowards()`
+- *Sequencer* - Added support for random `.wait()` interval
 
 ### Version 0.3.0
-
-- _Effects_ - Refactored `.aimTowards()` into `.rotateTowards()` and `.reachTowards()`
-- _Effects_ - Refactored how `.missed()` chooses the location to hit and now takes token size into account
-- _Effects_ - Added `.JB2A()` to automatically set the effect to handle their sprites in the best way possible
-- _Effects_ - Added `.randomizeMirror()` to randomly mirror sprites on the Y axis
-- _Effects_ - Added Mustache support in file names
+- *Effects* - Refactored `.aimTowards()` into `.rotateTowards()` and `.reachTowards()`
+- *Effects* - Refactored how `.missed()` chooses the location to hit and now takes token size into account
+- *Effects* - Added `.JB2A()` to automatically set the effect to handle their sprites in the best way possible
+- *Effects* - Added `.randomizeMirror()` to randomly mirror sprites on the Y axis
+- *Effects* - Added Mustache support in file names
 
 ### Version 0.2.0
-
-- _Sequencer_ - Added support for executing macros
-- _Sequencer_ - Added support for playing sounds
-- _Sequencer_ - Wrapped classes in proxies to simplify fluid interface (gets rid of `.done()` on effects and sounds)
+- *Sequencer* - Added support for executing macros
+- *Sequencer* - Added support for playing sounds
+- *Sequencer* - Wrapped classes in proxies to simplify fluid interface (gets rid of `.done()` on effects and sounds)
 
 ### Version 0.1.0
-
 - First implementation

--- a/docs/database-basics.md
+++ b/docs/database-basics.md
@@ -7,7 +7,7 @@ All of the methods are listed in the [Sequencer Database wiki article](database/
 You can open database viewer by calling:
 
 ```js
-Sequencer.DatabaseViewer.show();
+Sequencer.DatabaseViewer.show()
 ```
 
 or by pressing this button:
@@ -34,20 +34,19 @@ Registering files is as easy as shown below:
 const database = {
   effects: {
     generic: {
-      explosions:
-        "modules/your_module_name/Library/VFX/Generic/Explosion/explosion_01.webm",
-    },
+      explosions: "modules/your_module_name/Library/VFX/Generic/Explosion/explosion_01.webm"
+    }
   },
   sounds: {
     generic: {
       explosions: [
         "modules/your_module_name/Library/SFX/Generic/Explosion/explosion_01.ogg",
         "modules/your_module_name/Library/SFX/Generic/Explosion/explosion_02.ogg",
-        "modules/your_module_name/Library/SFX/Generic/Explosion/explosion_03.ogg",
-      ],
-    },
-  },
-};
+        "modules/your_module_name/Library/SFX/Generic/Explosion/explosion_03.ogg"
+      ]
+    }
+  }
+}
 
 Hooks.on("sequencerReady", () => {
   Sequencer.Database.registerEntries("your_module_name", database);
@@ -67,11 +66,11 @@ In the above example, I registered one explosion effect and three sounds, which 
 ```js
 new Sequence()
   .effect()
-  .file("your_module_name.effects.generic.explosions")
-  .atLocation(token)
-  .sound()
-  .file("your_module_name.sounds.generic.explosions")
-  .play();
+    .file("your_module_name.effects.generic.explosions")
+    .atLocation(token)
+    .sound()
+    .file("your_module_name.sounds.generic.explosions")
+  .play()
 ```
 
 This will play the explosion effect on the selected token, and play one of the sounds in the list, which is picked randomly. If `sounds.generic.explosions` was just one file, it would play just that one sound.
@@ -85,14 +84,12 @@ const database = {
       explosions: {
         red: "modules/your_module_name/Library/VFX/Generic/Explosion/explosion_red_01.webm",
         blue: "modules/your_module_name/Library/VFX/Generic/Explosion/explosion_blue_01.webm",
-        green:
-          "modules/your_module_name/Library/VFX/Generic/Explosion/explosion_green_01.webm",
-        purple:
-          "modules/your_module_name/Library/VFX/Generic/Explosion/explosion_purple_01.webm",
-      },
-    },
-  },
-};
+        green: "modules/your_module_name/Library/VFX/Generic/Explosion/explosion_green_01.webm",
+        purple: "modules/your_module_name/Library/VFX/Generic/Explosion/explosion_purple_01.webm"
+      }
+    }
+  }
+}
 ```
 
 A user could put this into the effect: `your_module_name.effects.generic.explosions` and the Sequencer would pick one random explosion from your colors.
@@ -105,15 +102,12 @@ In addition, if you define your structure like this:
 const database = {
   fire_bolt: {
     dark_red: {
-      "30ft":
-        "modules/jb2a_patreon/Library/Cantrip/Fire_Bolt/FireBolt_01_Dark_Red_30ft_1600x400.webm",
-      "60ft":
-        "modules/jb2a_patreon/Library/Cantrip/Fire_Bolt/FireBolt_01_Dark_Red_60ft_2800x400.webm",
-      "90ft":
-        "modules/jb2a_patreon/Library/Cantrip/Fire_Bolt/FireBolt_01_Dark_Red_90ft_4000x400.webm",
-    },
-  },
-};
+      "30ft": "modules/jb2a_patreon/Library/Cantrip/Fire_Bolt/FireBolt_01_Dark_Red_30ft_1600x400.webm",
+      "60ft": "modules/jb2a_patreon/Library/Cantrip/Fire_Bolt/FireBolt_01_Dark_Red_60ft_2800x400.webm",
+      "90ft": "modules/jb2a_patreon/Library/Cantrip/Fire_Bolt/FireBolt_01_Dark_Red_90ft_4000x400.webm"
+    }
+  }
+}
 ```
 
 This will make it so that if you pass `your_module_name.fire_bolt.dark_red` to an effect in the Sequencer, and the effect has a source and a target, the Sequencer will determine the best one to use for the distance between the source and the target.
@@ -140,29 +134,24 @@ In this case, you simply need to define a `_templates` section at the start of y
 
 ```js
 const database = {
-  _templates: {
-    // Grid size, start point, end point
-    default: [200, 0, 0],
-    ranged: [200, 200, 200],
+  _templates: { // Grid size, start point, end point
+    "default": [200, 0, 0],
+    "ranged": [200, 200, 200]
   },
   effects: {
     fire_bolt: {
       dark_red: {
         _template: "ranged",
-        "30ft":
-          "modules/jb2a_patreon/Library/Cantrip/Fire_Bolt/FireBolt_01_Dark_Red_30ft_1600x400.webm",
-        "60ft":
-          "modules/jb2a_patreon/Library/Cantrip/Fire_Bolt/FireBolt_01_Dark_Red_60ft_2800x400.webm",
-        "90ft":
-          "modules/jb2a_patreon/Library/Cantrip/Fire_Bolt/FireBolt_01_Dark_Red_90ft_4000x400.webm",
-      },
+        "30ft": "modules/jb2a_patreon/Library/Cantrip/Fire_Bolt/FireBolt_01_Dark_Red_30ft_1600x400.webm",
+        "60ft": "modules/jb2a_patreon/Library/Cantrip/Fire_Bolt/FireBolt_01_Dark_Red_60ft_2800x400.webm",
+        "90ft": "modules/jb2a_patreon/Library/Cantrip/Fire_Bolt/FireBolt_01_Dark_Red_90ft_4000x400.webm"
+      }
     },
     generic: {
-      explosions:
-        "modules/your_module_name/Library/VFX/Generic/Explosion/explosion_01.webm",
-    },
+      explosions: "modules/your_module_name/Library/VFX/Generic/Explosion/explosion_01.webm"
+    }
   },
-};
+}
 ```
 
 If there's no template found (like with `effects.generic.explosion`), it will use the "default" entry in the `_templates`.
@@ -184,11 +173,11 @@ const database = {
   complete: {
     _markers: {
       loop: { start: 1533, end: 5566 },
-      forcedEnd: 6566,
+      forcedEnd: 6566
     },
-    blue: "modules/jb2a_patreon/Library/1st_Level/Shield/Shield_03_Regular_Blue_Complete_400x400.webm",
-  },
-};
+    blue: "modules/jb2a_patreon/Library/1st_Level/Shield/Shield_03_Regular_Blue_Complete_400x400.webm"
+  }
+}
 ```
 
 This will cause the effect to be able to be looped without having to split the animation into "in", "loop", and "out" animations. The system will recognize the times given, and cause the effect to loop between 1533ms (at the 1.533 seconds mark of the effect) and 5566ms (5.566 seconds into the effect), and stay within that loop for as long as the effect persists.
@@ -210,17 +199,16 @@ const database = {
   sounds: {
     generic: {
       _timeRange: [0, 100],
-      explosion:
-        "modules/your_module_name/Library/SFX/Generic/Explosion/explosion_01.ogg",
+      explosion: "modules/your_module_name/Library/SFX/Generic/Explosion/explosion_01.ogg",
     },
     steps: [
       { file: "Music/Sound_Effects/Steps.wav", _timeRange: [0, 100] },
       { file: "Music/Sound_Effects/Steps.wav", _timeRange: [120, 220] },
       { file: "Music/Sound_Effects/Steps.wav", _timeRange: [240, 340] },
       { file: "Music/Sound_Effects/Steps.wav", _timeRange: [360, 480] },
-    ],
-  },
-};
+    ]
+  }
+}
 ```
 
 ## Timestamps within files
@@ -236,22 +224,29 @@ Whenever a timestamp is reached in the playback of the effect, the `sequencerEff
 ```js
 const database = {
   dagger: {
-    _timestamps: [1000],
-    white:
-      "modules/jb2a_patreon/Library/Generic/Weapon_Attacks/Ranged/Dagger01_01_Regular_White_30ft_1600x400.webm",
+    _timestamps: [
+      1000
+    ],
+    white: "modules/jb2a_patreon/Library/Generic/Weapon_Attacks/Ranged/Dagger01_01_Regular_White_30ft_1600x400.webm"
   },
   halberd: {
-    _timestamps: [[1000], [1250], [1250, 1350], [1250], [1250]],
-    dark_orangepurple: [
-      "modules/jb2a_patreon/Library/Generic/Weapon_Attacks/Melee/Halberd01_01_Dark_OrangePurple_800x600.webm",
-      "modules/jb2a_patreon/Library/Generic/Weapon_Attacks/Melee/Halberd01_02_Dark_OrangePurple_800x600.webm",
-      "modules/jb2a_patreon/Library/Generic/Weapon_Attacks/Melee/Halberd01_03_Dark_OrangePurple_800x600.webm",
-      "modules/jb2a_patreon/Library/Generic/Weapon_Attacks/Melee/Halberd01_04_Dark_OrangePurple_800x600.webm",
-      "modules/jb2a_patreon/Library/Generic/Weapon_Attacks/Melee/Halberd01_05_Dark_OrangePurple_800x600.webm",
-      "modules/jb2a_patreon/Library/Generic/Weapon_Attacks/Melee/Halberd01_06_Dark_OrangePurple_800x600.webm",
+    _timestamps: [
+      [1000],
+      [1250],
+      [1250, 1350],
+      [1250],
+      [1250]
     ],
-  },
-};
+    dark_orangepurple: [
+      'modules/jb2a_patreon/Library/Generic/Weapon_Attacks/Melee/Halberd01_01_Dark_OrangePurple_800x600.webm',
+      'modules/jb2a_patreon/Library/Generic/Weapon_Attacks/Melee/Halberd01_02_Dark_OrangePurple_800x600.webm',
+      'modules/jb2a_patreon/Library/Generic/Weapon_Attacks/Melee/Halberd01_03_Dark_OrangePurple_800x600.webm',
+      'modules/jb2a_patreon/Library/Generic/Weapon_Attacks/Melee/Halberd01_04_Dark_OrangePurple_800x600.webm',
+      'modules/jb2a_patreon/Library/Generic/Weapon_Attacks/Melee/Halberd01_05_Dark_OrangePurple_800x600.webm',
+      'modules/jb2a_patreon/Library/Generic/Weapon_Attacks/Melee/Halberd01_06_Dark_OrangePurple_800x600.webm'
+    ]
+  }
+}
 ```
 
 ## Flipbook textures
@@ -260,7 +255,7 @@ Another feature of the database is being able to bundle up files into flipbook a
 
 If you define `_flipbook: true` anywhere near files, they will become a single file that will animate accordingly. This is great for performance, since Foundry keeps all the textures in memory, which means that duplicating the same effect 100 times will cost almost as much as just 10.
 
-The default FPS for these assets is 24 frames per second.
+The default FPS for these assets is 24 frames per second. 
 
 ```js
 const database = {
@@ -268,10 +263,11 @@ const database = {
     file: [
       "flipbook_tests/border/TokenBorderCircle01_12_Regular_Blue_400x400_00000.webp",
       "flipbook_tests/border/TokenBorderCircle01_12_Regular_Blue_400x400_00001.webp",
-      ..."flipbook_tests/border/TokenBorderCircle01_12_Regular_Blue_400x400_00094.webp",
-      "flipbook_tests/border/TokenBorderCircle01_12_Regular_Blue_400x400_00095.webp",
+      ...
+      "flipbook_tests/border/TokenBorderCircle01_12_Regular_Blue_400x400_00094.webp",
+      "flipbook_tests/border/TokenBorderCircle01_12_Regular_Blue_400x400_00095.webp"
     ],
-    _flipbook: true,
+    _flipbook: true
   },
-};
+}
 ```

--- a/docs/database.md
+++ b/docs/database.md
@@ -3,7 +3,7 @@
 You can access the global Sequencer database through:
 
 ```js
-Sequencer.Database;
+Sequencer.Database
 ```
 
 ## Register Entries
@@ -11,10 +11,9 @@ Sequencer.Database;
 `Sequencer.Database.registerEntries(moduleName, entries)`
 
 It is recommended this is called in the `ready` hook:
-
 ```js
 Hooks.on("sequencerReady", () => {
-  Sequencer.Database.registerEntries("your_module_name", data);
+    Sequencer.Database.registerEntries("your_module_name", data);
 });
 ```
 
@@ -24,25 +23,24 @@ The `entries` parameter is expected to be an object in a structure like this:
 
 ```js
 const database = {
-  effects: {
-    generic: {
-      explosions:
-        "modules/your_module_name/Library/VFX/Generic/Explosion/explosion_01.webm",
-    },
-    lasershot: {
-      red: [
-        "modules/your_module_name/Library/VFX/LaserShots/lasershot_red_01.webm",
-        "modules/your_module_name/Library/VFX/LaserShots/lasershot_red_02.webm",
-        "modules/your_module_name/Library/VFX/LaserShots/lasershot_red_03.webm",
-      ],
-      blue: [
-        "modules/your_module_name/Library/VFX/LaserShots/lasershot_red_01.webm",
-        "modules/your_module_name/Library/VFX/LaserShots/lasershot_red_02.webm",
-        "modules/your_module_name/Library/VFX/LaserShots/lasershot_red_03.webm",
-      ],
-    },
-  },
-};
+    effects: {
+        generic: {
+            explosions: "modules/your_module_name/Library/VFX/Generic/Explosion/explosion_01.webm"
+        },
+        lasershot: {
+            red: [
+                "modules/your_module_name/Library/VFX/LaserShots/lasershot_red_01.webm",
+                "modules/your_module_name/Library/VFX/LaserShots/lasershot_red_02.webm",
+                "modules/your_module_name/Library/VFX/LaserShots/lasershot_red_03.webm",
+            ],
+            blue: [
+                "modules/your_module_name/Library/VFX/LaserShots/lasershot_red_01.webm",
+                "modules/your_module_name/Library/VFX/LaserShots/lasershot_red_02.webm",
+                "modules/your_module_name/Library/VFX/LaserShots/lasershot_red_03.webm",
+            ]
+        }
+    }
+}
 ```
 
 The structure can be in any form you want, as long as it eventually ends up at a file path, or an array of file paths (shown above).
@@ -62,6 +60,7 @@ This will return `SequencerFile` objects, ones used within the Sequencer ecosyst
 `Sequencer.Database.getPathsUnder(inDatabasePath)`
 
 This method will get all of the keys under a given path. If you have a database like this:
+
 
 ```js
 const database = {
@@ -89,3 +88,4 @@ Returns a list of strings.
 `Sequencer.Database.validateEntries(inModule)`
 
 This goes through each of the registered entries under a module name and checks if the paths exist and are spelled correctly.
+

--- a/docs/effect-manager.md
+++ b/docs/effect-manager.md
@@ -3,17 +3,15 @@
 You can access the global Sequencer Effect Manager through:
 
 ```js
-Sequencer.EffectManager;
+Sequencer.EffectManager
 ```
 
 ## Show Effect Manager
 
 You can either call this method:
-
 ```js
-Sequencer.EffectManager.show();
+Sequencer.EffectManager.show()
 ```
-
 Or press this button
 
 ![Image showing the button to open the Effect Manager](images/effect-viewer-button.jpg)
@@ -28,13 +26,13 @@ This will open this UI, where you can end any of your own effects currently play
 
 ```js
 inFilters = {
-  name: String, // From the .name() method on effects, can have wildcards in them (such as "fireball_*" to match anything that starts with "fireball_")
-  object: PlaceableObject | String, // Token, Tile, etc, or its id
-  source: PlaceableObject | Document | String, // Token, Tile, etc, Document, or an UUID
-  target: PlaceableObject | Document | String, // Token, Tile, etc, Document, or an UUID
-  sceneId: String, // Default to current scene ID
-  origin: String, // From the .origin() method on effects
-};
+    name: String, // From the .name() method on effects, can have wildcards in them (such as "fireball_*" to match anything that starts with "fireball_")
+    object: PlaceableObject|String,  // Token, Tile, etc, or its id
+    source: PlaceableObject|Document|String, // Token, Tile, etc, Document, or an UUID
+    target: PlaceableObject|Document|String, // Token, Tile, etc, Document, or an UUID
+    sceneId: String, // Default to current scene ID
+    origin: String // From the .origin() method on effects
+}
 ```
 
 <details>
@@ -42,18 +40,14 @@ inFilters = {
 
 ```js
 // Retrieves every effect named "test_effect"
-const effects = Sequencer.EffectManager.getEffects({ name: "test_effect" });
+const effects = Sequencer.EffectManager.getEffects({ name: "test_effect" })
 
 // Retrieves effects named "test_effect" on a specific token
-const effects = Sequencer.EffectManager.getEffects({
-  name: "test_effect",
-  object: token,
-});
+const effects = Sequencer.EffectManager.getEffects({ name: "test_effect", object: token })
 
 // Retrieves effects that have "test" in their name
-const effects = Sequencer.EffectManager.getEffects({ name: "*test*" });
+const effects = Sequencer.EffectManager.getEffects({ name: "*test*" })
 ```
-
 <strong>--------------------------------</strong>
 
 </details>
@@ -66,33 +60,31 @@ This will return any effect(s) that match the given filters. If an object is giv
 
 ```js
 inFilters = {
-  name: String, // From the .name() method on effects, can have wildcards in them (such as "fireball_*" to match anything that starts with "fireball_")
-  object: PlaceableObject | String, // Token, Tile, etc, or its id,
-  effects: CanvasEffect | String, // The actual effect, or an ID of an effect,
-  source: PlaceableObject | Document | String, // Token, Tile, etc, Document, or an UUID
-  target: PlaceableObject | Document | String, // Token, Tile, etc, Document, or an UUID
-  sceneId: String, // Default to current scene ID
-  origin: String, // From the .origin() method on effects
-};
+    name: String, // From the .name() method on effects, can have wildcards in them (such as "fireball_*" to match anything that starts with "fireball_")
+    object: PlaceableObject|String,  // Token, Tile, etc, or its id,
+    effects: CanvasEffect|String,  // The actual effect, or an ID of an effect,
+    source: PlaceableObject|Document|String, // Token, Tile, etc, Document, or an UUID
+    target: PlaceableObject|Document|String, // Token, Tile, etc, Document, or an UUID
+    sceneId: String, // Default to current scene ID
+    origin: String // From the .origin() method on effects
+}
 ```
 
 <details>
   <summary><strong>------ Click for examples ------</strong></summary><br />
 
 ```js
+
 // Ends every effect named "test_effect"
-await Sequencer.EffectManager.endEffects({ name: "test_effect" });
+await Sequencer.EffectManager.endEffects({ name: "test_effect" })
 
 // Ends effects named "test_effect" on a specific token
-await Sequencer.EffectManager.endEffects({
-  name: "test_effect",
-  object: token,
-});
+await Sequencer.EffectManager.endEffects({ name: "test_effect", object: token })
 
 // Ends effects that have "test" in their name
-const effects = Sequencer.EffectManager.getEffects({ name: "*test*" });
-```
+const effects = Sequencer.EffectManager.getEffects({ name: "*test*" })
 
+```
 <strong>--------------------------------</strong>
 
 </details>
@@ -109,13 +101,14 @@ You can only end effects you created, unless you are a GM.
   <summary><strong>------ Click for examples ------</strong></summary><br />
 
 ```js
+
 // Ends all effects in the current scene
-await Sequencer.EffectManager.endAllEffects();
+await Sequencer.EffectManager.endAllEffects()
 
 // Ends all effects in the scene with the ID of "ULohafjBlsTRST8F"
-await Sequencer.EffectManager.endAllEffects("ULohafjBlsTRST8F");
-```
+await Sequencer.EffectManager.endAllEffects("ULohafjBlsTRST8F")
 
+```
 <strong>--------------------------------</strong>
 
 </details>

--- a/docs/player.md
+++ b/docs/player.md
@@ -3,17 +3,15 @@
 You can access the global Sequencer Effect Manager through:
 
 ```js
-Sequencer.Player;
+Sequencer.Player
 ```
 
 ## Show Effect Player
 
 You can either call this method:
-
 ```js
-Sequencer.Player.show();
+Sequencer.Player.show()
 ```
-
 Or press this button
 
 ![Image showing the button to open the Effect Player](https://raw.githubusercontent.com/fantasycalendar/FoundryVTT-Sequencer/master/images/effect-player-button.jpg)

--- a/docs/preloader.md
+++ b/docs/preloader.md
@@ -7,7 +7,7 @@ Use the preloader with **caution** and **consideration** - not every client can 
 You can access the global Sequencer preloader through:
 
 ```js
-Sequencer.Preloader;
+Sequencer.Preloader
 ```
 
 ## Preload For Clients
@@ -21,30 +21,20 @@ Sequencer.Preloader.preloadForClients(files = string|array<string>, showProgress
 
 ```js
 // Preload a single file:
-await Sequencer.Preloader.preloadForClients("single/path/to/file.webm");
+await Sequencer.Preloader.preloadForClients("single/path/to/file.webm")
 
 // Preloading a list of files:
-await Sequencer.Preloader.preloadForClients([
-  "an/array/of/files.webm",
-  "that/all/gets/loaded.webm",
-]);
+await Sequencer.Preloader.preloadForClients(["an/array/of/files.webm", "that/all/gets/loaded.webm"])
 
 // Preload a single database path (which may contain multiple files)
-await Sequencer.Preloader.preloadForClients("jb2a.fire_bolt");
+await Sequencer.Preloader.preloadForClients("jb2a.fire_bolt")
 
 // Preload a list of database paths:
-await Sequencer.Preloader.preloadForClients([
-  "jb2a.fire_bolt",
-  "jb2a.ray_of_frost",
-]);
+await Sequencer.Preloader.preloadForClients(["jb2a.fire_bolt", "jb2a.ray_of_frost"])
 
 // Preloading a list of files and show the progress bar:
-await Sequencer.Preloader.preloadForClients(
-  ["an/array/of/files.webm", "that/all/gets/loaded.webm"],
-  true
-);
+await Sequencer.Preloader.preloadForClients(["an/array/of/files.webm", "that/all/gets/loaded.webm"], true)
 ```
-
 <strong>--------------------------------</strong>
 
 </details>
@@ -68,27 +58,20 @@ Sequencer.Preloader.preload(files = string|array<strings>, showProgressBar = boo
 
 ```js
 // Preload a single file:
-await Sequencer.Preloader.preload("single/path/to/file.webm");
+await Sequencer.Preloader.preload("single/path/to/file.webm")
 
 // Preloading a list of files:
-await Sequencer.Preloader.preload([
-  "an/array/of/files.webm",
-  "that/all/gets/loaded.webm",
-]);
+await Sequencer.Preloader.preload(["an/array/of/files.webm", "that/all/gets/loaded.webm"])
 
 // Preload a single database path (which may contain multiple files)
-await Sequencer.Preloader.preload("jb2a.fire_bolt");
+await Sequencer.Preloader.preload("jb2a.fire_bolt")
 
 // Preload a list of database paths:
-await Sequencer.Preloader.preload(["jb2a.fire_bolt", "jb2a.ray_of_frost"]);
+await Sequencer.Preloader.preload(["jb2a.fire_bolt", "jb2a.ray_of_frost"])
 
 // Preloading a list of files and show the progress bar:
-await Sequencer.Preloader.preload(
-  ["an/array/of/files.webm", "that/all/gets/loaded.webm"],
-  true
-);
+await Sequencer.Preloader.preload(["an/array/of/files.webm", "that/all/gets/loaded.webm"], true)
 ```
-
 <strong>--------------------------------</strong>
 
 </details>

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -7,17 +7,13 @@ Sequencer Presets allow you to register pieces of sequencer function calls and t
 You can access the global Sequencer Effect Manager through:
 
 ```js
-Sequencer.Presets;
+Sequencer.Presets
 ```
 
 ## Add Preset
 
 ```js
-Sequencer.Presets.add(
-  (inName = string),
-  (inFunction = Function),
-  (overwrite = boolean)
-);
+Sequencer.Presets.add(inName = string, inFunction = Function, overwrite = boolean)
 ```
 
 This adds a preset that can then be used in sequences - you register it as follows:
@@ -25,20 +21,8 @@ This adds a preset that can then be used in sequences - you register it as follo
 ```js
 Sequencer.Presets.add("breatheAnimation", (effect, args) => {
   return effect
-    .loopProperty("spriteContainer", "scale.x", {
-      from: 0.9,
-      to: 1.1,
-      duration: args?.duration ?? 1000,
-      pingPong: true,
-      ease: "easeInOutSine",
-    })
-    .loopProperty("spriteContainer", "scale.y", {
-      from: 0.9,
-      to: 1.1,
-      duration: args?.duration ?? 1000,
-      pingPong: true,
-      ease: "easeInOutSine",
-    });
+    .loopProperty("spriteContainer", "scale.x", { from: 0.9, to: 1.1, duration: args?.duration ?? 1000, pingPong: true, ease: "easeInOutSine" })
+    .loopProperty("spriteContainer", "scale.y", { from: 0.9, to: 1.1, duration: args?.duration ?? 1000, pingPong: true, ease: "easeInOutSine" });
 });
 ```
 
@@ -47,11 +31,11 @@ This way, you can then use this preset on any effect, like so:
 ```js
 new Sequence()
   .effect()
-  .file("jb2a.braziers.blue.bordered.01.05x05ft")
-  .atLocation(token)
-  .preset("breatheAnimation")
-  .persist()
-  .play();
+    .file('jb2a.braziers.blue.bordered.01.05x05ft')
+    .atLocation(token)
+    .preset("breatheAnimation")
+    .persist()
+  .play()
 ```
 
 Because `.atLocation()` returns the `EffectSection`, calling `.preset()` on it will pass that same effect into the preset callback. That function calls `.loopProperty()`, which is also an `EffectSection` method, which returns the same effect from the `.preset()` call, which allows `.persist()` to be applied to the same effect.
@@ -59,7 +43,7 @@ Because `.atLocation()` returns the `EffectSection`, calling `.preset()` on it w
 ## Get All Presets
 
 ```js
-Sequencer.Presets.getAll();
+Sequencer.Presets.getAll()
 ```
 
 Returns every preset as strings mapped to each preset function.
@@ -67,7 +51,7 @@ Returns every preset as strings mapped to each preset function.
 ## Get Preset
 
 ```js
-Sequencer.Presets.get("breatheAnimation");
+Sequencer.Presets.get("breatheAnimation")
 ```
 
 Returns the function for a given preset.

--- a/docs/sample-macros.md
+++ b/docs/sample-macros.md
@@ -6,19 +6,15 @@ Uses [Jack Kerouac's Animated Cartoon Spell Effets](https://foundryvtt.com/packa
 
 ```js
 new Sequence()
-  .effect(
-    "modules/animated-spell-effects-cartoon/spell-effects/cartoon/water/acid_splash_CIRCLE_01.webm"
-  )
-  .atLocation(canvas.tokens.controlled[0])
-  .scale(0.3, 0.6)
-  .randomRotation()
-  .effect(
-    "modules/animated-spell-effects-cartoon/spell-effects/cartoon/water/acid_splash_CIRCLE_01.webm"
-  )
-  .atLocation(canvas.tokens.controlled[1])
-  .scale(0.3, 0.6)
-  .randomRotation()
-  .play();
+    .effect("modules/animated-spell-effects-cartoon/spell-effects/cartoon/water/acid_splash_CIRCLE_01.webm")
+        .atLocation(canvas.tokens.controlled[0])
+        .scale(0.3, 0.6)
+        .randomRotation()
+    .effect("modules/animated-spell-effects-cartoon/spell-effects/cartoon/water/acid_splash_CIRCLE_01.webm")
+        .atLocation(canvas.tokens.controlled[1])
+        .scale(0.3, 0.6)
+        .randomRotation()
+    .play();
 ```
 
 ## Lightning Teleport
@@ -28,55 +24,52 @@ Uses [JB2A - Jules&Ben's Animated Assets](https://foundryvtt.com/packages/JB2A_D
 ![Animation showing the Sequencer](images/Animation2.gif)
 
 ```js
-let position = await warpgate.crosshairs.show(
-  {
+let position = await warpgate.crosshairs.show({
     size: 1,
     tag: randomID(),
     label: "Teleport to",
     drawOutline: false,
-    drawIcon: false,
-  },
-  {
-    show: async (crosshair) => {
-      new Sequence()
+    drawIcon: false
+}, { show: async (crosshair) => {
+
+    new Sequence()
         .effect()
-        .from(token)
-        .attachTo(crosshair)
-        .persist()
-        .opacity(0.5)
+            .from(token)
+            .attachTo(crosshair)
+            .persist()
+            .opacity(0.5)
         .play();
-    },
-  }
-);
+
+}})
 
 new Sequence()
-  .effect()
-  .file("jb2a.chain_lightning.primary.blue")
-  .atLocation(token)
-  .wait(300)
-  .effect()
-  .from(token)
-  .fadeIn(50)
-  .duration(550)
-  .fadeOut(250)
-  .filter("Blur")
-  .elevation(0)
-  .effect()
-  .file("jb2a.chain_lightning.secondary.blue")
-  .atLocation(token)
-  .stretchTo(position)
-  .elevation(0)
-  .wait(100)
-  .animation()
-  .on(token)
-  .teleportTo(position)
-  .snapToGrid()
-  .waitUntilFinished()
-  .effect()
-  .file("jb2a.static_electricity.03.blue")
-  .atLocation(token)
-  .scaleToObject()
-  .play();
+    .effect()
+        .file("jb2a.chain_lightning.primary.blue")
+        .atLocation(token)
+    .wait(300)
+    .effect()
+        .from(token)
+        .fadeIn(50)
+        .duration(550)
+        .fadeOut(250)
+        .filter("Blur")
+        .elevation(0)
+    .effect()
+        .file("jb2a.chain_lightning.secondary.blue")
+        .atLocation(token)
+        .stretchTo(position)
+        .elevation(0)
+    .wait(100)
+    .animation()
+        .on(token)
+        .teleportTo(position)
+        .snapToGrid()
+        .waitUntilFinished()
+    .effect()
+        .file("jb2a.static_electricity.03.blue")
+        .atLocation(token)
+        .scaleToObject()
+    .play();
 ```
 
 ## Spawn token with WarpGate and play effect
@@ -86,19 +79,17 @@ Uses [JB2A - Jules&Ben's Animated Assets](https://foundryvtt.com/packages/JB2A_D
 ![Two goblins being summoned](images/summon-creature.gif)
 
 ```js
-const [spawnedCreature] = await warpgate.spawn("Goblin", {
-  token: { alpha: 0 },
-});
+const [spawnedCreature] = await warpgate.spawn("Goblin", { token: { alpha: 0 }});
 
 new Sequence()
   .effect()
-  .file("jb2a.impact.003.green")
-  .atLocation(spawnedCreature)
+    .file("jb2a.impact.003.green")
+    .atLocation(spawnedCreature)
   .wait(300)
   .animation()
-  .on(spawnedCreature)
-  .opacity(1.0)
-  .play();
+    .on(spawnedCreature)
+    .opacity(1.0)
+  .play()
 ```
 
 ## Magic Missile
@@ -106,16 +97,15 @@ new Sequence()
 Uses [JB2A - Jules&Ben's Animated Assets](https://foundryvtt.com/packages/JB2A_DnD5e)
 
 ![One token firing three magic missiles on another token](images/magic_missile.gif)
-
 ```js
 new Sequence()
-  .effect()
-  .atLocation(canvas.tokens.controlled[0])
-  .stretchTo(canvas.tokens.controlled[1])
-  .file("jb2a.magic_missile")
-  .repeats(3, 200, 300)
-  .randomizeMirrorY()
-  .play();
+    .effect()
+        .atLocation(canvas.tokens.controlled[0])
+        .stretchTo(canvas.tokens.controlled[1])
+        .file("jb2a.magic_missile")
+        .repeats(3, 200, 300)
+        .randomizeMirrorY()
+    .play();
 ```
 
 ## Magic Circle
@@ -124,23 +114,21 @@ new Sequence()
 
 ```js
 new Sequence()
-  .effect()
-  .file(
-    "modules/jb2a_patreon/Library/Generic/Magic_Signs/Abjuration_01_Blue_Circle_800x800.webm"
-  )
-  .atLocation(canvas.tokens.controlled[0])
-  .scaleToObject(2)
-  .belowTokens()
-  .fadeIn(1500, { ease: "easeOutCubic", delay: 500 })
-  .fadeOut(1500)
-  .rotateIn(90, 2500, { ease: "easeInOutCubic" })
-  .rotateOut(350, 1500, { ease: "easeInCubic" })
-  .scaleIn(2, 2500, { ease: "easeInOutCubic" })
-  .scaleOut(0, 1500, { ease: "easeInCubic" })
-  .play();
+    .effect()
+        .file("modules/jb2a_patreon/Library/Generic/Magic_Signs/Abjuration_01_Blue_Circle_800x800.webm")
+        .atLocation(canvas.tokens.controlled[0])
+        .scaleToObject(2)
+        .belowTokens()
+        .fadeIn(1500, {ease: "easeOutCubic", delay: 500})
+        .fadeOut(1500)
+        .rotateIn(90, 2500, {ease: "easeInOutCubic"})
+        .rotateOut(350, 1500, {ease: "easeInCubic"})
+        .scaleIn(2, 2500, {ease: "easeInOutCubic"})
+        .scaleOut(0, 1500, {ease: "easeInCubic"})
+    .play()
 ```
 
-_Uses [JB2A - Jules&Ben's Animated Assets](https://foundryvtt.com/packages/JB2A_DnD5e)_
+*Uses [JB2A - Jules&Ben's Animated Assets](https://foundryvtt.com/packages/JB2A_DnD5e)*
 
 ## Lightning Strike
 
@@ -150,17 +138,17 @@ Uses [JB2A - Jules&Ben's Animated Assets](https://foundryvtt.com/packages/JB2A_D
 
 ```js
 new Sequence()
-  .effect()
-  .atLocation(canvas.tokens.controlled[0])
-  .file("Images/Effects/Lightning/LightningStrike_01{{letter}}_800x800.webm")
-  .setMustache({
-    // random letter between a to f
-    letter: () => {
-      const letters = ["a", "b", "c", "d", "e", "f"];
-      return letters[Math.floor(Math.random() * letters.length)];
-    },
-  })
-  .scale(2)
-  .randomizeMirrorX()
-  .play();
+    .effect()
+        .atLocation(canvas.tokens.controlled[0])
+        .file('Images/Effects/Lightning/LightningStrike_01{{letter}}_800x800.webm')
+        .setMustache({
+            // random letter between a to f
+            "letter": () => {
+                const letters = ['a', 'b', 'c', 'd', 'e', 'f']; 
+                return letters[Math.floor(Math.random() * letters.length)];
+            }
+        })
+        .scale(2)
+        .randomizeMirrorX()
+    .play();
 ```

--- a/docs/section-manager.md
+++ b/docs/section-manager.md
@@ -7,23 +7,20 @@ The section manager portion of Sequencer allows you to create your own implement
 You can access the global Sequencer Effect Manager through:
 
 ```js
-Sequencer.SectionManager;
+Sequencer.SectionManager
 ```
 
 ## Register Section
 
 ```js
-Sequencer.SectionManager.registerSection(
-  (inModuleName = string),
-  (inName = string),
-  (inClass = Class)
-);
+Sequencer.SectionManager.registerSection(inModuleName = string, inName = string, inClass = Class)
 ```
 
 This registers a class to the Sequencer so that it can be accessed within a `Sequence()` by the name you gave it. So if you register a class with the name of `myCustomSection`, inside of a Sequence you can then do this:
 
 ```js
-new Sequence().myCustomSection();
+new Sequence()
+  .myCustomSection()
 ```
 
 The reason you need to provide a module name as well is to ensure that we can easily see where errors are arising from, and to ensure conflicts between different modules registering their classes are caught.
@@ -37,14 +34,9 @@ The main idea behind a Section is to be a mutable interface - this means that an
 For example, the Effect Section method for setting the `.name()` of the Effect is defined like this within its class:
 
 ```js
-name(inName);
+name(inName)
 {
-  if (typeof inName !== "string")
-    throw this.sequence._throwError(
-      this,
-      "name",
-      "inName must be of type string"
-    );
+  if (typeof inName !== "string") throw this.sequence._throwError(this, "name", "inName must be of type string");
   this._name = inName;
   return this;
 }
@@ -65,7 +57,7 @@ Another core method to define within your custom Section class is `run()` - it i
 If you need to define variables, I recommend that you pre-define them within your Section's `constructor`, like so:
 
 ```js
-constructor(inSequence);
+constructor(inSequence)
 {
   super(inSequence);
   this.myProperty = false;
@@ -80,6 +72,7 @@ Here's an example of a custom section definition:
 
 ```js
 class NewSection extends Sequencer.BaseSection {
+
   constructor(inSequence) {
     super(inSequence);
     this.string = "";
@@ -91,13 +84,17 @@ class NewSection extends Sequencer.BaseSection {
   }
 
   async run() {
-    console.log(this.string);
+    console.log(this.string)
+      
   }
 }
 
-Sequencer.SectionManager.registerSection("myModule", "testing", NewSection);
+Sequencer.SectionManager.registerSection("myModule", "testing", NewSection)
 
-new Sequence().testing().setString("Let's do some damage!").play();
+new Sequence()
+  .testing()
+    .setString("Let's do some damage!")
+  .play()
 ```
 
 Running this macro will then result in this in the console - should you have the debug setting enabled for the Sequencer:

--- a/docs/sidebar.md
+++ b/docs/sidebar.md
@@ -1,34 +1,32 @@
 <!-- _sidebar.md -->
 
-- [Sequencer](/)
+* [Sequencer](/)
 
-- [Sequencer Basics](basics.md)
+* [Sequencer Basics](basics.md)
 
-- Basic Tutorials
-  - [Token Transformation Macro](tutorials/basic-transformation.md)
-  - [Linked Effect Between Tokens](tutorials/basic-linked.md)
-- Advanced Tutorials
+* Basic Tutorials
+  * [Token Transformation Macro](tutorials/basic-transformation.md)
+  * [Linked Effect Between Tokens](tutorials/basic-linked.md)
+  
+* Advanced Tutorials
+  * [Trap With Effects & Damage](tutorials/advanced-trap.md)
+  * [Fire Bolt & MidiQOL](tutorials/advanced-fire-bolt.md)
+  * [Shield & Dynamic Active Effects](tutorials/advanced-shield.md)
 
-  - [Trap With Effects & Damage](tutorials/advanced-trap.md)
-  - [Fire Bolt & MidiQOL](tutorials/advanced-fire-bolt.md)
-  - [Shield & Dynamic Active Effects](tutorials/advanced-shield.md)
+* [Sample Macros](sample-macros.md)
 
-- [Sample Macros](sample-macros.md)
+* [API](api/home.md)
+  * [Animation](api/animation.md)
+  * [Effect](api/effect.md)
+    * [Filters](api/filter.md)
+  * [Sound](api/sound.md)
+  * [Scrolling Text](api/scrolling-text.md)
 
-- [API](api/home.md)
-
-  - [Animation](api/animation.md)
-  - [Effect](api/effect.md)
-    - [Filters](api/filter.md)
-  - [Sound](api/sound.md)
-  - [Scrolling Text](api/scrolling-text.md)
-  - [Canvas Pan](api/canvas-pan.md)
-
-- Global
-  - [Database](database.md)
-  - [How to: Sequencer Database](database-basics.md)
-  - [Effect Manager](effect-manager.md)
-  - [Effect Player](player.md)
-  - [Preloader](preloader.md)
-  - [Section Manager](section-manager.md)
-  - [Presets](presets.md)
+* Global
+  * [Database](database.md)
+  * [How to: Sequencer Database](database-basics.md)
+  * [Effect Manager](effect-manager.md)
+  * [Effect Player](player.md)
+  * [Preloader](preloader.md)
+  * [Section Manager](section-manager.md)
+  * [Presets](presets.md)

--- a/docs/tutorials/advanced-fire-bolt.md
+++ b/docs/tutorials/advanced-fire-bolt.md
@@ -5,10 +5,9 @@ With this guide, we'll be creating the following effect:
 ![Firebolt missing and then hitting](../images/firebolt-tutorial/firebolt.gif)
 
 For this guide to work, you'll need the following modules installed:
-
-- [Midi Quality of Life Improvements](https://foundryvtt.com/packages/midi-qol/)
-- [Advanced Macros](https://foundryvtt.com/packages/advanced-macros)
-- [JB2A - Jules & Ben's Animated Assets](https://foundryvtt.com/packages/JB2A_DnD5e)
+* [Midi Quality of Life Improvements](https://foundryvtt.com/packages/midi-qol/)
+* [Advanced Macros](https://foundryvtt.com/packages/advanced-macros)
+* [JB2A - Jules & Ben's Animated Assets](https://foundryvtt.com/packages/JB2A_DnD5e)
 
 ## Initial setup
 
@@ -69,7 +68,6 @@ As you can see, all of these are very useful to help us determine the who, what,
 ## Creating The Macro
 
 **Steps:**
-
 1. [Determine the caster](#1-determine-the-caster)
 2. [Start on the Sequence](#2-start-on-the-sequence)
 3. [Add the Effect](#3-add-the-effect)
@@ -100,7 +98,7 @@ Start by creating a new sequence:
 ```js
 let tokenD = canvas.tokens.get(args[0].tokenId);
 
-new Sequence();
+new Sequence()
 ```
 
 <hr/>
@@ -112,7 +110,8 @@ Then add an effect to it:
 ```js
 let tokenD = canvas.tokens.get(args[0].tokenId);
 
-new Sequence().effect();
+new Sequence()
+    .effect()
 ```
 
 <hr/>
@@ -125,10 +124,8 @@ Let's add the Fire Bolt path to the effect - your effect might be located somewh
 let tokenD = canvas.tokens.get(args[0].tokenId);
 
 new Sequence()
-  .effect()
-  .file(
-    "modules/JB2A_DnD5e-0.2.1/Library/Cantrip/Fire_Bolt/FireBolt_01_Regular_Orange_30ft_1600x400.webm"
-  );
+    .effect()
+        .file("modules/JB2A_DnD5e-0.2.1/Library/Cantrip/Fire_Bolt/FireBolt_01_Regular_Orange_30ft_1600x400.webm")
 ```
 
 However, if you want to get fancy you can instead use the **Sequencer Database path** instead. You can get the Database Path to the firebolt by simply clicking on this button:
@@ -146,7 +143,9 @@ Paste that into the `.file()` section, so it looks like this:
 ```js
 let tokenD = canvas.tokens.get(args[0].tokenId);
 
-new Sequence().effect().file("jb2a.fire_bolt.orange");
+new Sequence()
+    .effect()
+        .file("jb2a.fire_bolt.orange")
 ```
 
 <hr/>
@@ -158,7 +157,10 @@ Now, let's make it play from the token who used the item:
 ```js
 let tokenD = canvas.tokens.get(args[0].tokenId);
 
-new Sequence().effect().file("jb2a.fire_bolt.orange").atLocation(tokenD);
+new Sequence()
+    .effect()
+        .file("jb2a.fire_bolt.orange")
+        .atLocation(tokenD)
 ```
 
 <hr/>
@@ -173,13 +175,13 @@ Then, let's make the effect **reach** towards the target:
 let tokenD = canvas.tokens.get(args[0].tokenId);
 
 new Sequence()
-  .effect()
-  .file("jb2a.fire_bolt.orange")
-  .atLocation(tokenD)
-  .stretchTo(args[0].targets[0]);
+    .effect()
+        .file("jb2a.fire_bolt.orange")
+        .atLocation(tokenD)
+        .stretchTo(args[0].targets[0])
 ```
 
-(_Note:_ the reason why we're using `.stretchTo()` here is because JB2A's projectiles already move towards the target inside of the effect itself)
+(*Note:* the reason why we're using `.stretchTo()` here is because JB2A's projectiles already move towards the target inside of the effect itself)
 
 <hr/>
 
@@ -187,7 +189,7 @@ new Sequence()
 
 But what if the attack missed?! No worries, the Sequencer can handle that. Just add `.missed(args[0].hitTargets.length === 0)` to it.
 
-What this means is that if there are tokens inside of `hitTargets` (as in, the attack DID hit something), it's false, meaning the effect _should_ hit the target.
+What this means is that if there are tokens inside of `hitTargets` (as in, the attack DID hit something), it's false, meaning the effect *should* hit the target.
 
 But if there are no tokens in `hitTargets`, that means that the attack missed, so it will be true, meaning the effect will target a random square around the target.
 
@@ -195,11 +197,11 @@ But if there are no tokens in `hitTargets`, that means that the attack missed, s
 let tokenD = canvas.tokens.get(args[0].tokenId);
 
 new Sequence()
-  .effect()
-  .file("jb2a.fire_bolt.orange")
-  .atLocation(tokenD)
-  .stretchTo(args[0].targets[0])
-  .missed(args[0].hitTargets.length === 0);
+    .effect()
+        .file("jb2a.fire_bolt.orange")
+        .atLocation(tokenD)
+        .stretchTo(args[0].targets[0])
+        .missed(args[0].hitTargets.length === 0)
 ```
 
 <hr/>
@@ -212,12 +214,12 @@ Now, you just need to finish off with `.play()`!
 let tokenD = canvas.tokens.get(args[0].tokenId);
 
 new Sequence()
-  .effect()
-  .file("jb2a.fire_bolt.orange")
-  .atLocation(tokenD)
-  .stretchTo(args[0].targets[0])
-  .missed(args[0].hitTargets.length === 0)
-  .play();
+    .effect()
+        .file("jb2a.fire_bolt.orange")
+        .atLocation(tokenD)
+        .stretchTo(args[0].targets[0])
+        .missed(args[0].hitTargets.length === 0)
+    .play()
 ```
 
 ## Now target a token, cast the spell (DO NOT CLICK THE MACRO), and ta-da! You have a Fire Bolt!

--- a/docs/tutorials/advanced-shield.md
+++ b/docs/tutorials/advanced-shield.md
@@ -5,11 +5,10 @@ With this guide, we'll be creating the following effect:
 ![Shield spell being cast and expiring with animations](../images/shield.gif)
 
 For this guide to work, you'll need the following modules installed:
-
-- [Times Up](https://foundryvtt.com/packages/times-up/)
-- [Dynamic Active Effects](https://foundryvtt.com/packages/dae)
-- [Advanced Macros](https://foundryvtt.com/packages/advanced-macros)
-- [JB2A - Jules & Ben's Animated Assets](https://foundryvtt.com/packages/JB2A_DnD5e)
+* [Times Up](https://foundryvtt.com/packages/times-up/)
+* [Dynamic Active Effects](https://foundryvtt.com/packages/dae)
+* [Advanced Macros](https://foundryvtt.com/packages/advanced-macros)
+* [JB2A - Jules & Ben's Animated Assets](https://foundryvtt.com/packages/JB2A_DnD5e)
 
 ## Shield Item & Effect
 
@@ -28,7 +27,6 @@ As you can see, the dynamic active effect ends at the end of the caster's next t
 Similar to the [Fire Bolt tutorial](tutorials/advanced-fire-bolt.md), we'll be using the `args` parameter given to the macro by Advanced Macros. Read that tutorial to get an understanding of what that means.
 
 **Steps:**
-
 1. [If starting or ending](_#1-If-starting-or-ending)
 2. [Determine the caster](_#2-Determine-the-caster)
 3. [Start on the Sequence](_#3-Start-on-the-Sequence)
@@ -48,12 +46,12 @@ Similar to the [Fire Bolt tutorial](tutorials/advanced-fire-bolt.md), we'll be u
 Since we're making an effect that can last for several rounds, Dynamic Active Effects changes the `args` a bit. If the effect lasts for a duration, `args[0]` can be `on` or `off`. "on" means the dynamic active effect just started and was applied to a target, and "off" means that the dynamic active effect ended on the target. With that in mind, we can start with this:
 
 ```js
-if (args[0] === "on") {
-  // If the dynamic active effect started
+if(args[0] === "on"){
+    // If the dynamic active effect started
 }
 
-if (args[0] === "off") {
-  // If the dynamic active effect ended
+if(args[0] === "off"){
+    // If the dynamic active effect ended
 }
 ```
 
@@ -66,12 +64,12 @@ To get the token who used the item, you just need to:
 ```js
 let tokenD = canvas.tokens.get(args[1].tokenId);
 
-if (args[0] === "on") {
-  // If the dynamic active effect started
+if(args[0] === "on"){
+    // If the dynamic active effect started
 }
 
-if (args[0] === "off") {
-  // If the dynamic active effect ended
+if(args[0] === "off"){
+    // If the dynamic active effect ended
 }
 ```
 
@@ -86,13 +84,15 @@ Similar to the fire bolt we created before, we'll need to start by creating a ne
 ```js
 let tokenD = canvas.tokens.get(args[1].tokenId);
 
-if (args[0] === "on") {
-  // If the dynamic active effect started
-  new Sequence().effect().file("jb2a.shield.01.intro.blue");
+if(args[0] === "on"){
+    // If the dynamic active effect started
+    new Sequence()
+        .effect()
+            .file("jb2a.shield.01.intro.blue")
 }
 
-if (args[0] === "off") {
-  // If the dynamic active effect ended
+if(args[0] === "off"){
+    // If the dynamic active effect ended
 }
 ```
 
@@ -105,13 +105,16 @@ Then, all we need to do is attach the effect to the caster with `attachTo` - thi
 ```js
 let tokenD = canvas.tokens.get(args[1].tokenId);
 
-if (args[0] === "on") {
-  // If the dynamic active effect started
-  new Sequence().effect().file("jb2a.shield.01.intro.blue").attachTo(tokenD);
+if(args[0] === "on"){
+    // If the dynamic active effect started
+    new Sequence()
+        .effect()
+            .file("jb2a.shield.01.intro.blue")
+            .attachTo(tokenD)
 }
 
-if (args[0] === "off") {
-  // If the dynamic active effect ended
+if(args[0] === "off"){
+    // If the dynamic active effect ended
 }
 ```
 
@@ -121,21 +124,22 @@ if (args[0] === "off") {
 
 The effect is a bit too big for the token, so I've also added `scale(0.5)`. In addition, since the effect we're playing is just the **intro**, we'll want to `waitUntilFinished`, as the next effect we're going to create is the **looping** shield effect.
 
+
 ```js
 let tokenD = canvas.tokens.get(args[1].tokenId);
 
-if (args[0] === "on") {
-  // If the dynamic active effect started
-  new Sequence()
-    .effect()
-    .file("jb2a.shield.01.intro.blue")
-    .attachTo(tokenD)
-    .scale(0.5)
-    .waitUntilFinished(-500);
+if(args[0] === "on"){
+    // If the dynamic active effect started
+    new Sequence()
+        .effect()
+            .file("jb2a.shield.01.intro.blue")
+            .attachTo(tokenD)
+            .scale(0.5)
+            .waitUntilFinished(-500)
 }
 
-if (args[0] === "off") {
-  // If the dynamic active effect ended
+if(args[0] === "off"){
+    // If the dynamic active effect ended
 }
 ```
 
@@ -150,22 +154,22 @@ As it is set up almost exactly the same as the previous effect - the only thing 
 ```js
 let tokenD = canvas.tokens.get(args[1].tokenId);
 
-if (args[0] === "on") {
-  // If the dynamic active effect started
-  new Sequence()
-    .effect()
-    .file("jb2a.shield.01.intro.blue")
-    .attachTo(tokenD)
-    .scale(0.5)
-    .waitUntilFinished(-500)
-    .effect()
-    .file("jb2a.shield.01.loop.blue")
-    .attachTo(tokenD)
-    .scale(0.5);
+if(args[0] === "on"){
+    // If the dynamic active effect started
+    new Sequence()
+        .effect()
+            .file("jb2a.shield.01.intro.blue")
+            .attachTo(tokenD)
+            .scale(0.5)
+            .waitUntilFinished(-500)
+        .effect()
+            .file("jb2a.shield.01.loop.blue")
+            .attachTo(tokenD)
+            .scale(0.5)
 }
 
-if (args[0] === "off") {
-  // If the dynamic active effect ended
+if(args[0] === "off"){
+    // If the dynamic active effect ended
 }
 ```
 
@@ -178,24 +182,24 @@ As we don't want the loop shield effect to end after it has finished one loop, w
 ```js
 let tokenD = canvas.tokens.get(args[1].tokenId);
 
-if (args[0] === "on") {
-  // If the dynamic active effect started
-  new Sequence()
-    .effect()
-    .file("jb2a.shield.01.intro.blue")
-    .attachTo(tokenD)
-    .scale(0.5)
-    .waitUntilFinished(-500)
-    .effect()
-    .file("jb2a.shield.01.loop.blue")
-    .attachTo(tokenD)
-    .scale(0.5)
-    .persist()
-    .name(`Shield-${tokenD.id}`);
+if(args[0] === "on"){
+    // If the dynamic active effect started
+    new Sequence()
+        .effect()
+            .file("jb2a.shield.01.intro.blue")
+            .attachTo(tokenD)
+            .scale(0.5)
+            .waitUntilFinished(-500)
+        .effect()
+            .file("jb2a.shield.01.loop.blue")
+            .attachTo(tokenD)
+            .scale(0.5)
+            .persist()
+            .name(`Shield-${tokenD.id}`)
 }
 
-if (args[0] === "off") {
-  // If the dynamic active effect ended
+if(args[0] === "off"){
+    // If the dynamic active effect ended
 }
 ```
 
@@ -208,26 +212,26 @@ Since the looping effect doesn't have a fade when it appears and disappears (bec
 ```js
 let tokenD = canvas.tokens.get(args[1].tokenId);
 
-if (args[0] === "on") {
-  // If the dynamic active effect started
-  new Sequence()
-    .effect()
-    .file("jb2a.shield.01.intro.blue")
-    .attachTo(tokenD)
-    .scale(0.5)
-    .waitUntilFinished(-500)
-    .effect()
-    .file("jb2a.shield.01.loop.blue")
-    .attachTo(tokenD)
-    .scale(0.5)
-    .persist()
-    .name(`Shield-${tokenD.id}`)
-    .fadeIn(300)
-    .fadeOut(300);
+if(args[0] === "on"){
+    // If the dynamic active effect started
+    new Sequence()
+        .effect()
+            .file("jb2a.shield.01.intro.blue")
+            .attachTo(tokenD)
+            .scale(0.5)
+            .waitUntilFinished(-500)
+        .effect()
+            .file("jb2a.shield.01.loop.blue")
+            .attachTo(tokenD)
+            .scale(0.5)
+            .persist()
+            .name(`Shield-${tokenD.id}`)
+            .fadeIn(300)
+            .fadeOut(300)
 }
 
-if (args[0] === "off") {
-  // If the dynamic active effect ended
+if(args[0] === "off"){
+    // If the dynamic active effect ended
 }
 ```
 
@@ -240,28 +244,28 @@ Last, but not least, we need to give the loop effect `extraEndDuration`. That me
 ```js
 let tokenD = canvas.tokens.get(args[1].tokenId);
 
-if (args[0] === "on") {
-  // If the dynamic active effect started
-  new Sequence()
-    .effect()
-    .file("jb2a.shield.01.intro.blue")
-    .attachTo(tokenD)
-    .scale(0.5)
-    .waitUntilFinished(-500)
-    .effect()
-    .file("jb2a.shield.01.loop.blue")
-    .attachTo(tokenD)
-    .scale(0.5)
-    .persist()
-    .name(`Shield-${tokenD.id}`)
-    .fadeIn(300)
-    .fadeOut(300)
-    .extraEndDuration(800)
-    .play();
+if(args[0] === "on"){
+     // If the dynamic active effect started
+    new Sequence()
+        .effect()
+            .file("jb2a.shield.01.intro.blue")
+            .attachTo(tokenD)
+            .scale(0.5)
+            .waitUntilFinished(-500)
+        .effect()
+            .file("jb2a.shield.01.loop.blue")
+            .attachTo(tokenD)
+            .scale(0.5)
+            .persist()
+            .name(`Shield-${tokenD.id}`)
+            .fadeIn(300)
+            .fadeOut(300)
+            .extraEndDuration(800)
+        .play()
 }
 
-if (args[0] === "off") {
-  // If the dynamic active effect ended
+if(args[0] === "off"){
+    // If the dynamic active effect ended
 }
 ```
 
@@ -276,32 +280,29 @@ In this case, we can use the `Sequencer.EffectManager` to end the effect that is
 ```js
 let tokenD = canvas.tokens.get(args[1].tokenId);
 
-if (args[0] === "on") {
-  // If the dynamic active effect started
-  new Sequence()
-    .effect()
-    .file("jb2a.shield.01.intro.blue")
-    .attachTo(tokenD)
-    .scale(0.5)
-    .waitUntilFinished(-500)
-    .effect()
-    .file("jb2a.shield.01.loop.blue")
-    .attachTo(tokenD)
-    .scale(0.5)
-    .persist()
-    .name(`Shield-${tokenD.id}`)
-    .fadeIn(300)
-    .fadeOut(300)
-    .extraEndDuration(800)
-    .play();
+if(args[0] === "on"){
+     // If the dynamic active effect started
+    new Sequence()
+        .effect()
+            .file("jb2a.shield.01.intro.blue")
+            .attachTo(tokenD)
+            .scale(0.5)
+            .waitUntilFinished(-500)
+        .effect()
+            .file("jb2a.shield.01.loop.blue")
+            .attachTo(tokenD)
+            .scale(0.5)
+            .persist()
+            .name(`Shield-${tokenD.id}`)
+            .fadeIn(300)
+            .fadeOut(300)
+            .extraEndDuration(800)
+        .play()
 }
 
-if (args[0] === "off") {
-  // If the dynamic active effect ended
-  Sequencer.EffectManager.endEffects({
-    name: `Shield-${tokenD.id}`,
-    object: tokenD,
-  });
+if(args[0] === "off"){
+    // If the dynamic active effect ended
+    Sequencer.EffectManager.endEffects({ name: `Shield-${tokenD.id}`, object: tokenD });
 }
 ```
 
@@ -316,39 +317,36 @@ By this point, you should be able to understand how the Sequence and effects fit
 ```js
 let tokenD = canvas.tokens.get(args[1].tokenId);
 
-if (args[0] === "on") {
-  // If the dynamic active effect started
-  new Sequence()
-    .effect()
-    .file("jb2a.shield.01.intro.blue")
-    .attachTo(tokenD)
-    .scale(0.5)
-    .waitUntilFinished(-500)
-    .effect()
-    .file("jb2a.shield.01.loop.blue")
-    .attachTo(tokenD)
-    .scale(0.5)
-    .persist()
-    .name(`Shield-${tokenD.id}`)
-    .fadeIn(300)
-    .fadeOut(300)
-    .extraEndDuration(800)
-    .play();
+if(args[0] === "on"){
+     // If the dynamic active effect started
+    new Sequence()
+        .effect()
+            .file("jb2a.shield.01.intro.blue")
+            .attachTo(tokenD)
+            .scale(0.5)
+            .waitUntilFinished(-500)
+        .effect()
+            .file("jb2a.shield.01.loop.blue")
+            .attachTo(tokenD)
+            .scale(0.5)
+            .persist()
+            .name(`Shield-${tokenD.id}`)
+            .fadeIn(300)
+            .fadeOut(300)
+            .extraEndDuration(800)
+        .play()
 }
 
-if (args[0] === "off") {
-  // If the dynamic active effect ended
-  Sequencer.EffectManager.endEffects({
-    name: `Shield-${tokenD.id}`,
-    object: tokenD,
-  });
+if(args[0] === "off"){
+    // If the dynamic active effect ended
+    Sequencer.EffectManager.endEffects({ name: `Shield-${tokenD.id}`, object: tokenD });
 
-  new Sequence()
-    .effect()
-    .file("jb2a.shield.01.outro_explode.blue")
-    .scale(0.5)
-    .attachTo(tokenD)
-    .play();
+    new Sequence()
+        .effect()
+            .file("jb2a.shield.01.outro_explode.blue")
+            .scale(0.5)
+            .attachTo(tokenD)
+        .play()
 }
 ```
 

--- a/docs/tutorials/advanced-trap.md
+++ b/docs/tutorials/advanced-trap.md
@@ -17,13 +17,11 @@ _[Click here to go to the advanced macro](#advanced-macro)_
 ![Token walking over the triggering tile, which stops it and then explodes](../images/trap-tutorial/trap-triggered-explosion-final.gif)
 
 ### Required modules
-
-- [Sequencer](https://foundryvtt.com/packages/sequencer)
-- [Monk's Active Tile Triggers](https://foundryvtt.com/packages/monks-active-tiles)
-- [JB2A - Jules & Ben's Animated Assets](https://foundryvtt.com/packages/JB2A_DnD5e) (or the patreon version)
+* [Sequencer](https://foundryvtt.com/packages/sequencer)
+* [Monk's Active Tile Triggers](https://foundryvtt.com/packages/monks-active-tiles)
+* [JB2A - Jules & Ben's Animated Assets](https://foundryvtt.com/packages/JB2A_DnD5e) (or the patreon version)
 
 **Steps:**
-
 1. [Create a new macro](#1-create-a-new-macro)
 2. [Add test line to Macro](#2-add-test-line-to-Macro)
 3. [Add a new tile and hide it](#3-add-a-new-tile-and-hide-it)
@@ -85,12 +83,10 @@ Replace the contents of the `Callback-Fire-Trap` macro with the following:
 
 ```js
 new Sequence()
-  .effect()
-  .file(
-    "modules/jb2a_patreon/Library/Generic/Explosion/Explosion_01_Orange_400x400.webm"
-  )
-  .atLocation(token)
-  .play();
+    .effect()
+        .file("modules/jb2a_patreon/Library/Generic/Explosion/Explosion_01_Orange_400x400.webm")
+        .atLocation(token)
+    .play()
 ```
 
 As you can see, the macro will start a `new Sequence()`, which will play an `.effect()` with a `.file()`, but `.atLocation()` determined by who triggered it, the **token**, and then we immediately `.play()` it!
@@ -124,15 +120,13 @@ Now, as you can see, when the tile is triggered, the tile stops the token from m
 ![Token walking over an arrow pressure plate and then arrows fly from the left and right.](../images/trap-tutorial/dungeon-trap-triggered-final.gif)
 
 ### Required Modules
-
-- [Sequencer](https://foundryvtt.com/packages/sequencer)
-- [Monk's Active Tile Triggers](https://foundryvtt.com/packages/monks-active-tiles)
-- [JB2A - Jules & Ben's Animated Assets](https://foundryvtt.com/packages/JB2A_DnD5e) (or the patreon version)
-- [Tagger](https://foundryvtt.com/packages/tagger)
-- [Midi Quality of Life Improvements](https://foundryvtt.com/packages/midi-qol)
+* [Sequencer](https://foundryvtt.com/packages/sequencer)
+* [Monk's Active Tile Triggers](https://foundryvtt.com/packages/monks-active-tiles)
+* [JB2A - Jules & Ben's Animated Assets](https://foundryvtt.com/packages/JB2A_DnD5e) (or the patreon version)
+* [Tagger](https://foundryvtt.com/packages/tagger)
+* [Midi Quality of Life Improvements](https://foundryvtt.com/packages/midi-qol)
 
 **Steps:**
-
 1. [Create three hidden tiles and tag them](#1-Create-three-hidden-tiles-and-tag-them)
 2. [Set up the triggers](#2-Set-up-the-triggers)
 3. [Create Trap Actor](#3-Create-Trap-Actor)
@@ -213,7 +207,9 @@ const trapItem = trapActor.items.getName("Arrow Trap Attack");
 
 new MidiQOL.TrapWorkflow(trapActor, trapItem, [token]);
 
-Hooks.once("midi-qol.RollComplete", async function (result) {});
+Hooks.once("midi-qol.RollComplete", async function(result){
+    
+});
 ```
 
 Once the `TrapWorkflow` is finished, the function inside the `midi-qol.RollComplete` hook will run, with the `result` of the trap's attack and saving throw available to us.
@@ -230,9 +226,11 @@ const trapItem = trapActor.items.getName("Arrow Trap Attack");
 
 new MidiQOL.TrapWorkflow(trapActor, trapItem, [token]);
 
-Hooks.once("midi-qol.RollComplete", async function (result) {
-  const [leftTile] = await Tagger.getByTag("left-trap-source");
-  const [rightTile] = await Tagger.getByTag("right-trap-source");
+Hooks.once("midi-qol.RollComplete", async function(result){
+    
+    const [leftTile] = await Tagger.getByTag('left-trap-source');
+    const [rightTile] = await Tagger.getByTag('right-trap-source');
+
 });
 ```
 
@@ -250,28 +248,31 @@ const trapItem = trapActor.items.getName("Arrow Trap Attack");
 
 new MidiQOL.TrapWorkflow(trapActor, trapItem, [token]);
 
-Hooks.once("midi-qol.RollComplete", async function (result) {
-  const [leftTile] = await Tagger.getByTag("left-trap-source");
-  const [rightTile] = await Tagger.getByTag("right-trap-source");
+Hooks.once("midi-qol.RollComplete", async function(result) {
 
-  new Sequence()
-    .effect()
-    .file("jb2a.arrow.physical.white.01")
-    .atLocation(leftTile, { randomOffset: true })
-    .stretchTo(rightTile, { randomOffset: true })
-    .repeats(5, 30, 60)
-    .effect()
-    .file("jb2a.arrow.physical.white.01")
-    .atLocation(rightTile, { randomOffset: true })
-    .stretchTo(leftTile, { randomOffset: true })
-    .repeats(5, 30, 60)
-    .play();
+    const [leftTile] = await Tagger.getByTag('left-trap-source');
+    const [rightTile] = await Tagger.getByTag('right-trap-source');
+
+    new Sequence()
+        .effect()
+            .file("jb2a.arrow.physical.white.01")
+            .atLocation(leftTile, { randomOffset: true })
+            .stretchTo(rightTile, { randomOffset: true })
+            .repeats(5, 30, 60)
+        .effect()
+            .file("jb2a.arrow.physical.white.01")
+            .atLocation(rightTile, { randomOffset: true })
+            .stretchTo(leftTile, { randomOffset: true })
+            .repeats(5, 30, 60)
+        .play();
+
 });
 ```
 
 As you can see, we're playing two `.effect()`s, both of the them are using the JB2A white arrow `.file()` in the Sequencer Database. These are being spawned at the left tile and attacking the right tile, and vice versa, but also targeting a random space within the opposite tile with a `randomOffset`. Each side `.repeats()` 5 times, with a random delay between 30 and 60 milliseconds.
 
 ![Token walking over an arrow pressure plate and then arrows fly from the left and right.](../images/trap-tutorial/dungeon-trap-triggered.gif)
+
 
 ### 9. Macro: Make arrows hit the token if they failed their save
 
@@ -294,25 +295,26 @@ const trapItem = trapActor.items.getName("Arrow Trap Attack");
 
 new MidiQOL.TrapWorkflow(trapActor, trapItem, [token]);
 
-Hooks.once("midi-qol.RollComplete", async function (result) {
-  const [leftTile] = await Tagger.getByTag("left-trap-source");
-  const [rightTile] = await Tagger.getByTag("right-trap-source");
+Hooks.once("midi-qol.RollComplete", async function(result) {
 
-  const leftTarget = result.failedSaves.has(token) ? token : leftTile;
-  const rightTarget = result.failedSaves.has(token) ? token : rightTile;
+    const [leftTile] = await Tagger.getByTag('left-trap-source');
+    const [rightTile] = await Tagger.getByTag('right-trap-source');
 
-  new Sequence()
-    .effect()
-    .file("jb2a.arrow.physical.white.01")
-    .atLocation(leftTile, { randomOffset: true })
-    .stretchTo(rightTarget, { randomOffset: true }) // <----------------------- Right here
-    .repeats(5, 30, 60)
-    .effect()
-    .file("jb2a.arrow.physical.white.01")
-    .atLocation(rightTile, { randomOffset: true })
-    .stretchTo(leftTarget, { randomOffset: true }) // <---------------------- and right here
-    .repeats(5, 30, 60)
-    .play();
+    const leftTarget = result.failedSaves.has(token) ? token : leftTile;
+    const rightTarget = result.failedSaves.has(token) ? token : rightTile;
+
+    new Sequence()
+        .effect()
+            .file("jb2a.arrow.physical.white.01")
+            .atLocation(leftTile, { randomOffset: true })
+            .stretchTo(rightTarget, { randomOffset: true }) // <----------------------- Right here
+            .repeats(5, 30, 60)
+        .effect()
+            .file("jb2a.arrow.physical.white.01")
+            .atLocation(rightTile, { randomOffset: true })
+            .stretchTo(leftTarget, { randomOffset: true }) // <---------------------- and right here
+            .repeats(5, 30, 60)
+        .play();
 });
 ```
 

--- a/docs/tutorials/basic-linked.md
+++ b/docs/tutorials/basic-linked.md
@@ -17,14 +17,12 @@ You will see a lot of `> Macro so far` after every step. You can click on this t
 <hr/>
 
 ## Required modules
-
-- [Sequencer](https://foundryvtt.com/packages/sequencer)
-- [JB2A - Jules & Ben's Animated Assets](https://foundryvtt.com/packages/JB2A_DnD5e) (or the patreon version)
+* [Sequencer](https://foundryvtt.com/packages/sequencer)
+* [JB2A - Jules & Ben's Animated Assets](https://foundryvtt.com/packages/JB2A_DnD5e) (or the patreon version)
 
 <hr/>
 
 ## Steps:
-
 1. [Create a new macro](#_1-Create-a-new-macro)
 2. [Make a new Sequence](#_2-Make-a-new-Sequence)
 3. [Start an effect section](#_3-Start-an-effect-section)
@@ -51,7 +49,7 @@ Since we can't play an effect without a Sequence, just add `new Sequence()` to t
   <summary><strong>Macro so far</strong></summary><br />
 
 ```js
-new Sequence();
+new Sequence()
 ```
 
 </details>
@@ -66,7 +64,8 @@ And, since we're playing an effect, you'll want to add `.effect()` below the `ne
   <summary><strong>Macro so far</strong></summary><br />
 
 ```js
-new Sequence().effect();
+new Sequence()
+    .effect()
 ```
 
 </details>
@@ -87,11 +86,14 @@ Simply click on the `Database` button on the `jb2a.energy_beam.normal.bluepink.0
 
 Add a `.file()` section and paste the copied `jb2a.energy_beam.normal.bluepink.03` into it.
 
+
 <details>
   <summary><strong>Macro so far</strong></summary><br />
 
 ```js
-new Sequence().effect().file("jb2a.energy_beam.normal.bluepink.03");
+new Sequence()
+    .effect()
+        .file("jb2a.energy_beam.normal.bluepink.03")
 ```
 
 </details>
@@ -107,9 +109,9 @@ In order for the effect to be **attached to** the token, we'll need to add `.att
 
 ```js
 new Sequence()
-  .effect()
-  .file("jb2a.energy_beam.normal.bluepink.03")
-  .attachTo(token);
+    .effect()
+        .file("jb2a.energy_beam.normal.bluepink.03")
+        .attachTo(token)
 ```
 
 </details>
@@ -137,10 +139,10 @@ Then, add the following to the bottom of the macro - `.stretchTo(target, { attac
 const target = game.user.targets.first();
 
 new Sequence()
-  .effect()
-  .file("jb2a.energy_beam.normal.bluepink.03")
-  .attachTo(token)
-  .stretchTo(target, { attachTo: true });
+    .effect()
+        .file("jb2a.energy_beam.normal.bluepink.03")
+        .attachTo(token)
+        .stretchTo(target, { attachTo: true })
 ```
 
 </details>
@@ -160,12 +162,12 @@ Then, at the very end, just add `.play()`. Think of the Sequence as the recipe, 
 const target = game.user.targets.first();
 
 new Sequence()
-  .effect()
-  .file("jb2a.energy_beam.normal.bluepink.03")
-  .attachTo(token)
-  .stretchTo(target, { attachTo: true })
-  .persist()
-  .play();
+    .effect()
+        .file("jb2a.energy_beam.normal.bluepink.03")
+        .attachTo(token)
+        .stretchTo(target, { attachTo: true })
+        .persist()
+    .play()
 ```
 
 </details>
@@ -180,12 +182,12 @@ Select a token, target another token, run the macro.
 const target = game.user.targets.first();
 
 new Sequence()
-  .effect()
-  .file("jb2a.energy_beam.normal.bluepink.03")
-  .attachTo(token)
-  .stretchTo(target, { attachTo: true })
-  .persist()
-  .play();
+    .effect()
+        .file("jb2a.energy_beam.normal.bluepink.03")
+        .attachTo(token)
+        .stretchTo(target, { attachTo: true })
+        .persist()
+    .play()
 ```
 
 ![A token that is linked from a human into a werebear, and then back.](../images/basic-tutorials/linked-token-effect.gif)

--- a/docs/tutorials/basic-transformation.md
+++ b/docs/tutorials/basic-transformation.md
@@ -17,14 +17,12 @@ You will see a lot of `> Macro so far` after every step. You can click on this t
 <hr/>
 
 ## Required modules
-
-- [Sequencer](https://foundryvtt.com/packages/sequencer)
-- [JB2A - Jules & Ben's Animated Assets](https://foundryvtt.com/packages/JB2A_DnD5e) (or the patreon version)
+* [Sequencer](https://foundryvtt.com/packages/sequencer)
+* [JB2A - Jules & Ben's Animated Assets](https://foundryvtt.com/packages/JB2A_DnD5e) (or the patreon version)
 
 <hr/>
 
 ## Steps:
-
 1. [Create a new macro](#_1-Create-a-new-macro)
 2. [Determine token transformation images](#_2-Determine-token-transformation-images)
 3. [Pick the right image](#_3-Pick-the-right-image)
@@ -67,8 +65,7 @@ So now we know which images to use, but not which one to switch to. Using this c
 let notTransformed = "systems/dnd5e/tokens/humanoid/Thug.webp";
 let transformed = "systems/dnd5e/tokens/humanoid/Werebear.webp";
 
-let img =
-  token.document.texture.src === notTransformed ? transformed : notTransformed;
+let img = token.document.texture.src === notTransformed ? transformed : notTransformed;
 ```
 
 This means that if the currently selected token's image is the same as `notTransformed` (the token has not yet transformed), we assign `systems/dnd5e/tokens/humanoid/Werebear.webp` into the variable called `img`.
@@ -92,7 +89,7 @@ let transformed = "systems/dnd5e/tokens/humanoid/Werebear.webp";
 
 let img = token.data.img === notTransformed ? transformed : notTransformed;
 
-new Sequence();
+new Sequence()
 ```
 
 </details>
@@ -112,7 +109,8 @@ let transformed = "systems/dnd5e/tokens/humanoid/Werebear.webp";
 
 let img = token.data.img === notTransformed ? transformed : notTransformed;
 
-new Sequence().effect();
+new Sequence()
+    .effect()
 ```
 
 </details>
@@ -133,10 +131,8 @@ let transformed = "systems/dnd5e/tokens/humanoid/Werebear.webp";
 let img = token.data.img === notTransformed ? transformed : notTransformed;
 
 new Sequence()
-  .effect()
-  .file(
-    "modules/jb2a_patreon/Library/2nd_Level/Misty_Step/MistyStep_02_Regular_Blue_400x400.webm"
-  );
+    .effect()
+        .file("modules/jb2a_patreon/Library/2nd_Level/Misty_Step/MistyStep_02_Regular_Blue_400x400.webm")
 ```
 
 </details>
@@ -157,12 +153,16 @@ Paste that into the `.file()` section. It is always recommended to use the Datab
   <summary><strong>Macro so far</strong></summary><br />
 
 ```js
+
 let notTransformed = "systems/dnd5e/tokens/humanoid/Thug.webp";
 let transformed = "systems/dnd5e/tokens/humanoid/Werebear.webp";
 
 let img = token.data.img === notTransformed ? transformed : notTransformed;
 
-new Sequence().effect().file("jb2a.misty_step.02.blue");
+new Sequence()
+    .effect()
+        .file("jb2a.misty_step.02.blue")
+
 ```
 
 </details>
@@ -184,7 +184,11 @@ let transformed = "systems/dnd5e/tokens/humanoid/Werebear.webp";
 
 let img = token.data.img === notTransformed ? transformed : notTransformed;
 
-new Sequence().effect().file("jb2a.misty_step.02.blue").atLocation(token);
+new Sequence()
+    .effect()
+        .file("jb2a.misty_step.02.blue")
+        .atLocation(token)
+
 ```
 
 </details>
@@ -207,11 +211,12 @@ let transformed = "systems/dnd5e/tokens/humanoid/Werebear.webp";
 let img = token.data.img === notTransformed ? transformed : notTransformed;
 
 new Sequence()
-  .effect()
-  .file("jb2a.misty_step.02.blue")
-  .atLocation(token)
-  .scaleToObject(2.5)
-  .randomRotation();
+    .effect()
+        .file("jb2a.misty_step.02.blue")
+        .atLocation(token)
+        .scaleToObject(2.5)
+        .randomRotation()
+
 ```
 
 </details>
@@ -232,12 +237,13 @@ let transformed = "systems/dnd5e/tokens/humanoid/Werebear.webp";
 let img = token.data.img === notTransformed ? transformed : notTransformed;
 
 new Sequence()
-  .effect()
-  .file("jb2a.misty_step.02.blue")
-  .atLocation(token)
-  .scaleToObject(2.5)
-  .randomRotation()
-  .wait(1500);
+    .effect()
+        .file("jb2a.misty_step.02.blue")
+        .atLocation(token)
+        .scaleToObject(2.5)
+        .randomRotation()
+    .wait(1500)
+
 ```
 
 </details>
@@ -252,6 +258,7 @@ This means that once the `.wait(1500)` finishes after 1500ms, **then** we'll **d
 
 Then, at the very end, just add `.play()`. Think of the Sequence as the recipe, but in order to actually cook everything we've assembled (the effect, the wait, the token image switch), we need to `.play()` it.
 
+
 <details>
   <summary><strong>Macro so far</strong></summary><br />
 
@@ -262,16 +269,17 @@ let transformed = "systems/dnd5e/tokens/humanoid/Werebear.webp";
 let img = token.data.img === notTransformed ? transformed : notTransformed;
 
 new Sequence()
-  .effect()
-  .file("jb2a.misty_step.02.blue")
-  .atLocation(token)
-  .scaleToObject(2.5)
-  .randomRotation()
-  .wait(1500)
-  .thenDo(() => {
-    token.document.update({ img });
-  })
-  .play();
+    .effect()
+        .file("jb2a.misty_step.02.blue")
+        .atLocation(token)
+        .scaleToObject(2.5)
+        .randomRotation()
+    .wait(1500)
+    .thenDo(() => {
+        token.document.update({ img });
+    })
+    .play()
+
 ```
 
 </details>
@@ -281,24 +289,24 @@ new Sequence()
 ## Finished macro:
 
 ```js
-let notTransformed = "systems/dnd5e/tokens/humanoid/Thug.webp";
-let transformed = "systems/dnd5e/tokens/humanoid/Werebear.webp";
+
+let notTransformed = 'systems/dnd5e/tokens/humanoid/Thug.webp';
+let transformed = 'systems/dnd5e/tokens/humanoid/Werebear.webp';
 
 let img = token.data.img === notTransformed ? transformed : notTransformed;
 
 new Sequence()
-  .effect()
-  .file(
-    "modules/jb2a_patreon/Library/2nd_Level/Misty_Step/MistyStep_02_Regular_Blue_400x400.webm"
-  )
-  .atLocation(token)
-  .scaleToObject(2.5)
-  .randomRotation()
-  .wait(1500)
-  .thenDo(() => {
-    token.document.update({ img });
-  })
-  .play();
+    .effect()
+        .file("modules/jb2a_patreon/Library/2nd_Level/Misty_Step/MistyStep_02_Regular_Blue_400x400.webm")
+        .atLocation(token)
+        .scaleToObject(2.5)
+        .randomRotation()
+    .wait(1500)
+    .thenDo(() => {
+        token.document.update({ img });
+    })
+    .play()
+
 ```
 
 ![A token that transforms from a human into a werebear, and then back.](../images/basic-tutorials/transformation.gif)

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "prepare": "husky install"
   },
   "lint-staged": {
-    "*.{js,css,md}": "prettier --write"
+    "*.{js,css}": "prettier --write"
   }
 }


### PR DESCRIPTION
Markdown files when formatted were killing some of the intentional spacing in `new Sequencer()` examples. This makes sure `md` files won't be formatted in the future and reverts the formatting that was already committed in #156.