### PR TITLE
Add `fullyQualified` option for `Sequencer.Database.getPathsUnder`

### DIFF
--- a/src/modules/sequencer-database.js
+++ b/src/modules/sequencer-database.js
@@ -251,7 +251,12 @@ class Database {
    */
   getPathsUnder(
     inPath,
-    { ranges = false, arrays = false, match = false } = {}
+    {
+      ranges = false,
+      arrays = false,
+      match = false,
+      fullyQualified = false,
+    } = {}
   ) {
     if (typeof inPath !== "string")
       return this._throwError("getPathsUnder", "inPath must be of type string");
@@ -264,7 +269,7 @@ class Database {
         "getPathsUnder",
         `Could not find ${inPath} in database`
       );
-    let entries = this.flattenedEntries.filter((e) => {
+    const entries = this.flattenedEntries.filter((e) => {
       return (
         (e.startsWith(inPath + ".") || e === inPath) &&
         (!match || (match && e.match(match)))
@@ -275,8 +280,8 @@ class Database {
       entries
         .map((e) => (!arrays ? e.split(CONSTANTS.ARRAY_REGEX)[0] : e))
         .map((e) => (!ranges ? e.split(CONSTANTS.FEET_REGEX)[0] : e))
-        .map((e) => e.split(inPath)[1])
-        .map((e) => (e ? e.split(".")[1] : ""))
+        .map((e) => (!fullyQualified ? e.split(inPath)[1] : e))
+        .map((e) => (!fullyQualified ? (e ? e.split(".")[1] : "") : e))
         .filter(Boolean)
     );
   }


### PR DESCRIPTION
The hardest part about this change is frankly figuring out the name but unfortunately I couldn't think of anything too illustrative. I'd be open to any changes in terms of name... or really any changes.

Here's the output:
```js
Sequencer.Database.getPathsUnder("jb2a.magic_signs.rune.02.complete"); // ["01", "02", "03", ...]
Sequencer.Database.getPathsUnder("jb2a.magic_signs.rune.02.complete", { fullyQualified: true }); // ["jb2a.magic_signs.rune.02.complete.01.blue", "jb2a.magic_signs.rune.02.complete.01.green", "jb2a.magic_signs.rune.02.complete.01.grey" ...]
```

This basically makes it both recursive and fully qualified, i.e. contains the starting portion. This way everything output is a completely valid entry name. I found a macro or two where this'd be useful.