### PR TITLE
Fixes a small typo

### DIFF
--- a/src/modules/sequencer-effect-manager.js
+++ b/src/modules/sequencer-effect-manager.js
@@ -592,7 +592,7 @@ export default class SequencerEffectManager {
         if (!CanvasEffect.checkValid(effect[1])) {
           if (!game.user.isGM) return;
           lib.custom_warning(
-            `Sequencer``Removed effect from ${inDocument.uuid} as it no longer had a valid source or target`
+            `Sequencer | Removed effect from ${inDocument.uuid} as it no longer had a valid source or target`
           );
           return flagManager.removeFlags(inDocument.uuid, effect);
         }


### PR DESCRIPTION
The code was \`Sequencer\`\`...\` which made "Sequencer" get interpreted as a tagged function rather than as text and try to call it, erroring. I believe the intent was \`Sequencer | ...`.