### PR TITLE
Wait for mesh to generate before animating

### DIFF
--- a/src/lib/canvas-lib.js
+++ b/src/lib/canvas-lib.js
@@ -171,8 +171,8 @@ export function get_object_position(
     }
   } else if (obj instanceof Token) {
     pos = {
-      x: obj.mesh.x,
-      y: obj.mesh.y,
+      x: obj.x + obj.scene.grid.size / 2,
+      y: obj.y + obj.scene.grid.size / 2
     };
 
     if (exact) {

--- a/src/lib/canvas-lib.js
+++ b/src/lib/canvas-lib.js
@@ -170,13 +170,13 @@ export function get_object_position(
       pos.y += Math.abs(obj.document.height / 2);
     }
   } else if (obj instanceof Token) {
+    const halfSize = get_object_dimensions(obj, true);
     pos = {
-      x: obj.x + obj.scene.grid.size / 2,
-      y: obj.y + obj.scene.grid.size / 2
+      x: obj.x + halfSize.width,
+      y: obj.y + halfSize.height
     };
 
     if (exact) {
-      const halfSize = get_object_dimensions(obj, true);
       pos.x -= halfSize.width;
       pos.y -= halfSize.height;
     }

--- a/src/sections/animation.js
+++ b/src/sections/animation.js
@@ -271,9 +271,9 @@ class AnimationSection extends Section {
     let refreshTokenID;
 
     return await new Promise(resolve => {
-      refreshTokenID = Hooks.on('drawToken', async (tokenDoc) => {
+      refreshTokenID = Hooks.on('refreshToken', async (tokenDoc) => {
         if (tokenDoc.document.actorId !== token.document.actorId || !token.mesh) return;
-        Hooks.off('drawToken', refreshTokenID);
+        Hooks.off('refreshToken', refreshTokenID);
         resolve();
       })
     })
@@ -285,10 +285,10 @@ class AnimationSection extends Section {
   async _execute() {
     if (!(await this._shouldPlay())) return;
     let self = this;
-    await this._waitForUnloadedMesh(this._originObject);
     this._basicDelay = lib.random_float_between(this._delayMin, this._delayMax);
     return new Promise(async (resolve) => {
       setTimeout(async () => {
+        await this._waitForUnloadedMesh(this._originObject);
         if (this._shouldAsync) {
           await self.run();
         } else {

--- a/src/sections/animation.js
+++ b/src/sections/animation.js
@@ -253,9 +253,40 @@ class AnimationSection extends Section {
   /**
    * @private
    */
+  async _waitForUnloadedMesh(obj) {
+    let token;
+
+    if (obj instanceof Token) {
+      token = obj;
+    } else if (obj instanceof TokenDocument) {
+      token = obj.object;
+    } else {
+      return;
+    }
+
+    if (token.mesh != null) {
+      return;
+    }
+
+    let refreshTokenID;
+
+    return await new Promise(resolve => {
+      refreshTokenID = Hooks.on('refreshToken', async (tokenDoc) => {
+        if (!token.mesh)
+        if (tokenDoc.document.actorId !== token.actorId) return;
+        Hooks.off('refreshToken', refreshTokenID);
+        resolve();
+      })
+    })
+  }
+
+  /**
+   * @private
+   */
   async _execute() {
     if (!(await this._shouldPlay())) return;
     let self = this;
+    await this._waitForUnloadedMesh(this._originObject);
     this._basicDelay = lib.random_float_between(this._delayMin, this._delayMax);
     return new Promise(async (resolve) => {
       setTimeout(async () => {

--- a/src/sections/animation.js
+++ b/src/sections/animation.js
@@ -253,7 +253,7 @@ class AnimationSection extends Section {
   /**
    * @private
    */
-  async _waitForUnloadedMesh(obj) {
+  async _waitForTokenRefresh(obj) {
     let token;
 
     if (obj instanceof Token) {
@@ -288,7 +288,7 @@ class AnimationSection extends Section {
     this._basicDelay = lib.random_float_between(this._delayMin, this._delayMax);
     return new Promise(async (resolve) => {
       setTimeout(async () => {
-        await this._waitForUnloadedMesh(this._originObject);
+        await this._waitForTokenRefresh(this._originObject);
         if (this._shouldAsync) {
           await self.run();
         } else {

--- a/src/sections/animation.js
+++ b/src/sections/animation.js
@@ -258,23 +258,22 @@ class AnimationSection extends Section {
 
     if (obj instanceof Token) {
       token = obj;
-    } else if (obj instanceof TokenDocument) {
-      token = obj.object;
-    } else {
-      return;
     }
 
-    if (token.mesh != null) {
+    if (obj instanceof TokenDocument) {
+      token = obj.object;
+    }
+
+    if (token == null || token.mesh != null) {
       return;
     }
 
     let refreshTokenID;
 
     return await new Promise(resolve => {
-      refreshTokenID = Hooks.on('refreshToken', async (tokenDoc) => {
-        if (!token.mesh)
-        if (tokenDoc.document.actorId !== token.actorId) return;
-        Hooks.off('refreshToken', refreshTokenID);
+      refreshTokenID = Hooks.on('drawToken', async (tokenDoc) => {
+        if (tokenDoc.document.actorId !== token.document.actorId || !token.mesh) return;
+        Hooks.off('drawToken', refreshTokenID);
         resolve();
       })
     })


### PR DESCRIPTION
As of Foundry v11, createEmbeddedDocuments returns the token document before the mesh is created. If this document is used in sequencer it would throw an error. This waits until the mesh is generated before running any animation.