### PR TITLE
Add missing import of SequencerPreloader

### DIFF
--- a/src/sockets.js
+++ b/src/sockets.js
@@ -4,6 +4,7 @@ import FlagManager from "./utils/flag-manager.js";
 import SequencerSoundManager from "./modules/sequencer-sound-manager.js";
 import SequencerEffectManager from "./modules/sequencer-effect-manager.js";
 import SequencerFoundryReplicator from "./modules/sequencer-foundry-replicator.js";
+import SequencerPreloader from './modules/sequencer-preloader.js'
 
 export const SOCKET_HANDLERS = {
   PLAY_EFFECT: "playEffect",


### PR DESCRIPTION
When trying to preload assets with for example
```js
Sequencer.Preloader.preloadForClients(['jb2a.pack_hound_missile.orange'])
```
Sequencer throws an error because `SequencerPreloader` is not in scope in the sockets.js file.