### PR TITLE
Fix sound `atLocation` version check

### DIFF
--- a/src/sections/sound.js
+++ b/src/sections/sound.js
@@ -156,7 +156,7 @@ class SoundSection extends Section {
 			}
 		}
 
-		if (playData.location && game.version.split(".")[0] === "12") {
+		if (playData.location && game.version.split(".")[0] !== "12") {
 			if (this.sequence.softFail) {
 				playData.play = false;
 			} else {


### PR DESCRIPTION
When trying to play sounds in Foundry V12 with the new `atLocation` feature, I received an error that `atLocation` for sounds is not supported on Foundry V11 .

I believe the check in sound.js should only throw this error on foundry versions other than 12 instead of for version 12.