### PR TITLE
Use `sortLayer` instead of elevation for effect layer ordering

### DIFF
--- a/docs/api/effect.md
+++ b/docs/api/effect.md
@@ -830,9 +830,17 @@ Causes the effect to be played above the interface layer, which makes the effect
 
 `.zIndex(1)`
 
-Sets the z-index of the effect, potentially displaying it on top of or below other effects
+Sets the z-index of the effect, potentially displaying it on top of or below other effects on the same elevation and sortLayer (v12 only).
 
 **Note:** If you have called [`.belowTokens()`](#below-tokens) or [`.belowTiles()`](#below-tiles), the effect is placed on an entirely different layer, with its own z-index and will be sorted within that layer.
+
+## Sort Layer
+
+### Only supported in Foundry v12
+
+`sortLayer(PrimaryCanvasGroup.SORT_LAYERS.WEATHER + 100)`
+
+Sets the sort layer of the effect. This value is used to determine layer ordering between entities of the same elevation. Foundry sorts canvas object first by elevation, second by their sortLayer and third by their z-index. Default is 800, which is above tokens and below weather effects.
 
 ## Animate Property
 

--- a/src/canvas-effects/canvas-effect.js
+++ b/src/canvas-effects/canvas-effect.js
@@ -91,6 +91,7 @@ const SyncGroups = {
 export default class CanvasEffect extends PIXI.Container {
 	#elevation = 0;
 	#sort = 0;
+	#sortLayer = 800
 
 	constructor(inData) {
 		super();
@@ -156,6 +157,15 @@ export default class CanvasEffect extends PIXI.Container {
 
 	set sort(value) {
 		this.#sort = value;
+	}
+
+	/** @type {number} */
+	get sortLayer() {
+		return this.#sortLayer;
+	}
+
+	set sortLayer(value) {
+		this.#sortLayer = value;
 	}
 
 	get context() {
@@ -1950,6 +1960,7 @@ export default class CanvasEffect extends PIXI.Container {
 		this.elevation = effectElevation;
 		this.zIndex = this.sort;
 		this.sort += 100;
+		this.sortLayer = this.data.sortLayer
 		if (this.parent) {
 			this.parent.sortChildren();
 		}

--- a/src/sections/effect.js
+++ b/src/sections/effect.js
@@ -49,6 +49,7 @@ export default class EffectSection extends Section {
 		this._screenSpacePosition = null;
 		this._screenSpaceScale = null;
 		this._elevation = null;
+		this._sortLayer = 800;
 		this._masks = [];
 		this._tiedDocuments = [];
 		this._selfMask = false;
@@ -1362,8 +1363,12 @@ export default class EffectSection extends Section {
 				"belowTokens",
 				"inBool must be of type boolean"
 			);
-		if (!inBool) return this;
-		return this.elevation(0, { absolute: true });
+		if (game.release.generation >= 12) {
+			return this.sortLayer(inBool ? 600 : 800);
+		} else {
+			if (!inBool) return this;
+			return this.elevation(0, { absolute: true });
+		}
 	}
 
 	/**
@@ -1379,8 +1384,12 @@ export default class EffectSection extends Section {
 				"belowTokens",
 				"inBool must be of type boolean"
 			);
-		if (!inBool) return this;
-		return this.elevation(-1, { absolute: true });
+		if (game.release.generation >= 12) {
+			return this.sortLayer(inBool ? 300 : 500);
+		} else {
+			if (!inBool) return this;
+			return this.elevation(-1, { absolute: true });
+		}
 	}
 
 	/**
@@ -1460,7 +1469,20 @@ export default class EffectSection extends Section {
 	}
 
 	/**
-	 * Sets the zIndex of the effect, potentially displaying it on top of other effects the same elevation
+	 * Changes the effect's sortLayer, potentially displaying effects below tiles, above tokens or even weather effects
+	 * in case of identical elevations
+	 *
+	 * @param {Number} inSortLayer
+	 * @param {Object} inOptions
+	 * @returns {EffectSection}
+	 */
+	sortLayer(inSortLayer, inOptions = {}) {
+		this._sortLayer = inSortLayer;
+		return this;
+	}
+
+	/**
+	 * Sets the zIndex of the effect, potentially displaying it on top of other effects the same elevation and sort
 	 *
 	 * @param {Number} inZIndex
 	 * @returns {EffectSection}
@@ -2353,6 +2375,7 @@ export default class EffectSection extends Section {
 			randomRotation: this._randomRotation,
 			scaleToObject: this._scaleToObject,
 			elevation: this._elevation,
+			sortLayer: this._sortLayer,
 			aboveLighting: this._aboveLighting,
 			aboveInterface: this._aboveInterface,
 			xray: this._xray,


### PR DESCRIPTION
This PR changes the way how `belowTokens` and `belowTiles` work in FoundryVTT V12.
Instead of changing the elevation to fixed offsets, which in V12 could easily render effects in unexpected order, especially on maps that make heavy use of elevations. These functions now instead set the `sortLayer` property on the effect canvas Object.
This `sortLayer` value is used in v12 to tie-break the render order of objects within the same elevation, which now sort objects first by `elevation`, secondarily by `sortLayer` and finally by the `sort` property, which is named zIndex in sequencer.