### PR TITLE
Support for non-english characters

### DIFF
--- a/src/lib/lib.js
+++ b/src/lib/lib.js
@@ -478,7 +478,7 @@ export function section_proxy_wrap(inClass) {
 export function str_to_search_regex_str(str) {
   return str
     .trim()
-    .replace(/([^A-Za-z0-9 .*_-])/g, "\\$1")
+    .replace(/([^\p{L}\p{N} .*_-])/gu, "\\$1")
     .replace(/\*+/g, ".*?");
 }
 


### PR DESCRIPTION
The regex [A-Za-z0-9 .*_-] only includes English letters and digits. To make this regex work with any language, we can use Unicode property escapes, which are supported in modern JavaScript engines.

