### PR TITLE
Prefetch files in parallel

### DIFF
--- a/src/modules/sequencer-preloader.js
+++ b/src/modules/sequencer-preloader.js
@@ -208,13 +208,14 @@ const SequencerPreloader = {
 
     return new Promise(async (resolve) => {
       let numFilesFailedToLoad = 0;
-      for (let src of inSrcs) {
+      const loadingPromises = inSrcs.map(async (inSrcs) => {
         const blob = await SequencerFileCache.loadFile(src, true);
         if (showProgressBar) LoadingBar.incrementProgress();
         if (!blob) {
           numFilesFailedToLoad++;
         }
-      }
+      })
+      await Promise.allSettled(loadingPromises)
       const timeTaken = (performance.now() - startTime) / 1000;
       let failedToLoad = ` (${numFilesFailedToLoad} failed to load)`;
       lib.debug(

--- a/src/modules/sequencer.js
+++ b/src/modules/sequencer.js
@@ -53,12 +53,13 @@ export default class Sequence {
     }
     Hooks.callAll("createSequencerSequence", this);
     lib.debug("Initializing sections");
-    if (preload) {
-      const preloadPromises = this.sections
-        .filter(section => !!section._file)
-        .map(section => Sequencer.Preloader.preloadForClients(section._file))
-      await Promise.allSettled(preloadPromises)
-    }
+    const preloadPromises = this.sections.map(async (section) => {
+      await section._initialize()
+      if (preload && section._file) {
+        await Sequencer.Preloader.preloadForClients(section._file)
+      }
+    })
+    await Promise.allSettled(preloadPromises)
     SequenceManager.RunningSequences.add(this.id, this);
     this.effectIndex = 0;
     lib.debug("Playing sections");

--- a/src/modules/sequencer.js
+++ b/src/modules/sequencer.js
@@ -53,11 +53,11 @@ export default class Sequence {
     }
     Hooks.callAll("createSequencerSequence", this);
     lib.debug("Initializing sections");
-    for (let section of this.sections) {
-      await section._initialize();
-	    if(preload && section._file){
-		    await Sequencer.Preloader.preloadForClients(section._file)
-	    }
+    if (preload) {
+      const preloadPromises = this.sections
+        .filter(section => !!section._file)
+        .map(section => Sequencer.Preloader.preloadForClients(section._file))
+      await Promise.allSettled(preloadPromises)
     }
     SequenceManager.RunningSequences.add(this.id, this);
     this.effectIndex = 0;

--- a/src/modules/sequencer.js
+++ b/src/modules/sequencer.js
@@ -53,13 +53,12 @@ export default class Sequence {
     }
     Hooks.callAll("createSequencerSequence", this);
     lib.debug("Initializing sections");
-    const preloadPromises = this.sections.map(async (section) => {
-      await section._initialize()
-      if (preload && section._file) {
-        await Sequencer.Preloader.preloadForClients(section._file)
-      }
-    })
-    await Promise.allSettled(preloadPromises)
+    const initializationPromises = this.sections.map((section) => section._initialize())
+    await Promise.allSettled(initializationPromises)
+    if (preload) {
+      const preloadFiles = this.sections.filter(section => !!section._file).map(section => section._file)
+      await Sequencer.Preloader.preloadForClients(preloadFiles)
+    }
     SequenceManager.RunningSequences.add(this.id, this);
     this.effectIndex = 0;
     lib.debug("Playing sections");


### PR DESCRIPTION
With this PR, prefetching of assets when `.play({ prefetch: true })` is used is done in parallel instead of sequentially.