### PR TITLE
Set effect render visibility based on token vision

### DIFF
--- a/src/canvas-effects/canvas-effect.js
+++ b/src/canvas-effects/canvas-effect.js
@@ -679,8 +679,12 @@ export default class CanvasEffect extends PIXI.Container {
 
 		// Otherwise, test visibility against current sight polygons
 		if (!this.useVisionMasking) return true;
-		const offsetX = this.width / 2;
-		const offsetY = this.height / 2;
+		const width = this.width
+		const height = this.height
+		const x = this.x
+		const y = this.y;
+		const offsetX = width / 2;
+		const offsetY = height / 2;
 
 		const corners = [
 			[offsetX, offsetY],
@@ -688,13 +692,13 @@ export default class CanvasEffect extends PIXI.Container {
 			[-offsetX, offsetY],
 			[-offsetX, -offsetY],
 		].map(([offsetX, offsetY]) => ({
-			x: this.x + offsetX, y: this.y + offsetY
+			x: x + offsetX, y: y + offsetY
 		}));
-		const tolerance = Math.min(this.width, this.height) / 2;
+		const tolerance = Math.min(width, height) / 2;
 		const cornersVisibility = corners.some((corner) =>
 			canvas.visibility.testVisibility(corner, { tolerance: 0, object: this })
 		);
-		const centerVisibility = canvas.visibility.testVisibility({ x: this.x, y: this.y }, { tolerance, object: this });
+		const centerVisibility = canvas.visibility.testVisibility({ x: x, y: y }, { tolerance, object: this });
 		return cornersVisibility || centerVisibility;
 	}
 


### PR DESCRIPTION
Currently, masking is used exclusively to hide effects that are occluded from token vision by walls etc. 
This means currently every effect on the game canvas is still rendered and then cut from the canvas, even though it might not be visible at all.

This PR calculates visibility of effects based on the 4 corners and the center (+tolerance) of the effects bounding box with the vision polygon and sets the `PIXI.Container`s visibility to `false` in case it is not visible.


With this PR I also want to open a discussion about effect visibility masking:
Masking of effects completely removes every possibility that the drawing of effects can be batched which introduces a significant performance bottleneck.
Since now effects that are not inside the players vision (based on the effects boundin box) are not shown at all, I think it can make sense to move the masking operation of effects behind a performance setting.
Maybe by default only apply masking if foundry performance is set to high or above with a separate override in the Sequencer settings?