### PR TITLE
add teleport flag to updates

### DIFF
--- a/src/sections/animation.js
+++ b/src/sections/animation.js
@@ -246,7 +246,7 @@ class AnimationSection extends Section {
       SOCKET_HANDLERS.UPDATE_DOCUMENT,
       uuid,
       updates,
-      { animate, animation }
+      { animate, animation, teleport: !!this._teleportTo }
     );
   }
 


### PR DESCRIPTION
As far as I can tell this is the only spot where it should be added. With regions, there's a new "teleport" property on token updates which is set when a region causes a teleport. By setting it when using `teleportTo` it should make sure nothing is triggered that shouldn't be for a "normal" teleportation.