### PR TITLE
fix: Use interface audio context

### DIFF
--- a/src/canvas-effects/canvas-effect.js
+++ b/src/canvas-effects/canvas-effect.js
@@ -455,8 +455,7 @@ export default class CanvasEffect extends PIXI.Container {
 			: 1.0;
 		inVideo.muted = !this.data.volume;
 		inVideo.volume =
-			(this.data.volume ?? 0) *
-			game.settings.get("core", "globalInterfaceVolume");
+			(this.data.volume ?? 0);
 
 		if (!this._video) {
 			this._video = inVideo;
@@ -3006,9 +3005,7 @@ export default class CanvasEffect extends PIXI.Container {
 		SequencerAnimationEngine.addAnimation(this.id, {
 			target: this,
 			propertyName: "video.volume",
-			to:
-				(this.data.volume ?? 0) *
-				game.settings.get("core", "globalInterfaceVolume"),
+			to: (this.data.volume ?? 0),
 			duration: fadeInAudio.duration,
 			ease: fadeInAudio.ease,
 			delay: fadeInAudio.delay,

--- a/src/modules/sequencer-sound-manager.js
+++ b/src/modules/sequencer-sound-manager.js
@@ -68,7 +68,7 @@ export default class SequencerSoundManager {
 
 		// Given that this is also affected by normal Foundry environment controls, do we want to multiply it by interface volume as well?
 		data.volume = playSound
-			? (data.volume ?? 0.8) * game.settings.get("core", "globalInterfaceVolume")
+			? (data.volume ?? 0.8)
 			: 0.0;
 
 		let sound;
@@ -85,6 +85,7 @@ export default class SequencerSoundManager {
 				location = canvaslib.get_random_offset(location, data.randomOffset.source);
 			}
 			sound = await canvas.sounds.playAtPosition(data.src, location, data.locationOptions?.radius || 5, {
+				context: game.audio.interface,
 				gmAlways: false,
 				walls: false,
 				easing: true,
@@ -94,6 +95,7 @@ export default class SequencerSoundManager {
 			});
 		} else {
 			sound = await game.audio.play(data.src, {
+				context: game.audio.interface,
 				...data.locationOptions,
 				volume: data.fadeIn ? 0 : data.volume,
 				loop: data.loop,


### PR DESCRIPTION
Fix for #294 

Question: Is backward compatibility with Foundry 11 required?