### PR TITLE
Enable batching for vision mask shader

### DIFF
--- a/src/batchShader.js
+++ b/src/batchShader.js
@@ -1,0 +1,8 @@
+import VisionSamplerShader from "./lib/filters/vision-mask-filter.js";
+import { debug } from "./lib/lib.js";
+
+export default function registerBatchShader() {
+  VisionSamplerShader.registerPlugin();
+
+  debug("Registered VisionBatchShader");
+}

--- a/src/lib/filters/vision-mask-filter.js
+++ b/src/lib/filters/vision-mask-filter.js
@@ -1,52 +1,80 @@
 export default class VisionSamplerShader extends BaseSamplerShader {
-  /** @override */
-  static classPluginName = null;
+	// /** @override */
+	static classPluginName = "sequencerVisionBatch";
 
-  /** @inheritdoc */
-  static vertexShader = `
-      precision ${PIXI.settings.PRECISION_VERTEX} float;
-      attribute vec2 aVertexPosition;
-      attribute vec2 aTextureCoord;
-      uniform mat3 projectionMatrix;
-      uniform vec2 screenDimensions;
-      varying vec2 vUvsMask;
-      varying vec2 vUvs;
-      void main() {
-        vUvs = aTextureCoord;
-        vUvsMask = aVertexPosition / screenDimensions;
-        gl_Position = vec4((projectionMatrix * vec3(aVertexPosition, 1.0)).xy, 0.0, 1.0);
-      }
-    `;
+	/** @override */
+	static reservedTextureUnits = 1; // We need a texture unit for the occlusion texture
 
-  /** @inheritdoc */
-  static fragmentShader = `
-      precision ${PIXI.settings.PRECISION_FRAGMENT} float;
-      varying vec2 vUvs;
-      varying vec2 vUvsMask;
-      uniform vec4 tintAlpha;
-      uniform sampler2D sampler;
-      uniform sampler2D maskSampler;
-      uniform bool enableVisionMasking;
-      void main() {
-        float mask = enableVisionMasking ? texture2D(maskSampler, vUvsMask).r : 1.0;
-        gl_FragColor = texture2D(sampler, vUvs) * tintAlpha * mask;
-      }
-    `;
+	/**
+	 * The batch vertex shader source.
+	 * @type {string}
+	 */
+	static batchVertexShader = `
+    #version 300 es
+    precision ${PIXI.settings.PRECISION_VERTEX} float;
 
-  /** @inheritdoc */
-  static defaultUniforms = {
-    tintAlpha: [1, 1, 1, 1],
-    sampler: 0,
-    maskSampler: 0,
-    screenDimensions: [1, 1],
-    enableVisionMasking: false,
-  };
+    uniform vec2 screenDimensions;
 
-  /** @override */
-  _preRender(mesh) {
-    super._preRender(mesh);
-    this.uniforms.maskSampler = canvas.masks.vision.renderTexture;
-    this.uniforms.screenDimensions = canvas.screenDimensions;
-    this.uniforms.enableVisionMasking = canvas?.visibility?.visible ?? canvas?.effects?.visibility?.visible ?? true;
-  }
+    in vec2 aVertexPosition;
+    in vec2 aTextureCoord;
+    in vec4 aColor;
+    in float aTextureId;
+    uniform mat3 projectionMatrix;
+    uniform mat3 translationMatrix;
+    uniform vec4 tint;
+    out vec2 vTextureCoord;
+    out vec2 vVisionCoord;
+    flat out vec4 vColor;
+    flat out float vTextureId;
+
+    void main(void){
+      gl_Position = vec4((projectionMatrix * translationMatrix * vec3(aVertexPosition, 1.0)).xy, 0.0, 1.0);
+      vTextureCoord = aTextureCoord;
+      vTextureId = aTextureId;
+      vColor = aColor * tint;
+      vVisionCoord = aVertexPosition / screenDimensions;
+    }
+  `;
+
+	/**
+	 * The batch fragment shader source.
+	 * @type {string}
+	 */
+	static batchFragmentShader = `
+    #version 300 es
+    precision ${PIXI.settings.PRECISION_FRAGMENT} float;
+    in vec2 vTextureCoord;
+    flat in vec4 vColor;
+    flat in float vTextureId;
+    in vec2 vVisionCoord;
+    uniform bool enableVisionMasking;
+    uniform sampler2D visionMaskTexture;
+    uniform sampler2D uSamplers[%count%];
+    out vec4 fragColor;
+
+    #define texture2D texture
+
+    void main(void){
+      float mask = enableVisionMasking ? texture2D(visionMaskTexture, vVisionCoord).r : 1.0;
+      vec4 color;
+      %forloop%
+      fragColor = color * vColor * mask;
+    }
+  `;
+
+	/** @override */
+	static batchDefaultUniforms(maxTex) {
+		return {
+			screenDimensions: [1, 1],
+			visionMaskTexture: maxTex,
+		};
+	}
+
+	/** @override */
+	static _preRenderBatch(batchRenderer) {
+		const uniforms = batchRenderer._shader.uniforms;
+		uniforms.screenDimensions = canvas.screenDimensions;
+		uniforms.enableVisionMasking = canvas?.visibility?.visible ?? canvas?.effects?.visibility?.visible ?? true;
+		batchRenderer.renderer.texture.bind(canvas.masks.vision.renderTexture, uniforms.visionMaskTexture);
+	}
 }

--- a/src/module.js
+++ b/src/module.js
@@ -2,6 +2,7 @@ import "./styles/module.scss";
 
 import { registerSettings, migrateSettings } from "./settings.js";
 import registerLayers from "./layers.js";
+import registerBatchShader from "./batchShader.js";
 import registerHotkeys from "./hotkeys.js";
 import registerTypes from "../typings/typings.js";
 import { registerSocket } from "./sockets.js";
@@ -138,6 +139,7 @@ function initializeModule() {
   registerLayers();
   registerHotkeys();
   registerLibwrappers();
+  registerBatchShader();
 
   SequencerAboveUILayer.setup();
   SequencerEffectManager.setup();


### PR DESCRIPTION
This replaces the individual rendering code for the vision sample shader with a batched version. This means probably between 15 and 31 or so effects could be drawn in one drawCall[^1] with vision masking.

[^1]: Once filters for sequencer effects are not set when they are not needed