### PR TITLE
Optimizations to enable canvas-effect batching in most cases

### DIFF
--- a/docs/api/effect.md
+++ b/docs/api/effect.md
@@ -864,6 +864,7 @@ Valid targets are `sprite` (the effect itself) and `spriteContainer` (the effect
 
 Animatable properties are as follows:
 - `sprite`
+  - `alpha`
   - `position.x`
   - `position.y`
   - `rotation` (degrees)
@@ -918,6 +919,7 @@ Valid targets are `sprite` (the effect itself) and `spriteContainer` (the effect
 
 Animatable properties are as follows:
 - `sprite`
+  - `alpha`
   - `position.x`
   - `position.y`
   - `rotation` (degrees)

--- a/examples/effects/39-animateProperty.js
+++ b/examples/effects/39-animateProperty.js
@@ -31,13 +31,13 @@
 		.effect()
 		.file("jb2a.braziers.orange.bordered.01.05x05ft")
 		.atLocation({ x: 2200, y: 1100 })
-		.animateProperty('sprite', 'alpha', {from: 0, to: 1, duration: 2500})
+		.animateProperty('sprite', 'alpha', {from: 0, to: 1, duration: 2500, absolute: true})
 		.text("sprite alpha", textStyle)
 
 		.effect()
 		.file("jb2a.braziers.orange.bordered.01.05x05ft")
 		.atLocation({ x: 2600, y: 1100 })
-		.animateProperty('alphaFilter', 'alpha', {from: 0, to: 1, duration: 2500})
+		.animateProperty('alphaFilter', 'alpha', {from: 0, to: 1, duration: 2500, absolute: true})
 		.text("alphaFilter ", textStyle)
 
 		.effect()

--- a/src/canvas-effects/canvas-effect.js
+++ b/src/canvas-effects/canvas-effect.js
@@ -1878,9 +1878,7 @@ export default class CanvasEffect extends PIXI.Container {
 			}
 		}
 
-		this.alphaFilter = new PIXI.filters.AlphaFilter(this.data.opacity);
-		this.alphaFilter.id = this.id + "-alphaFilter";
-		this.sprite.filters.push(this.alphaFilter);
+		this.sprite.alpha = this.data.opacity
 
 		let spriteOffsetX = this.data.spriteOffset?.x ?? 0;
 		let spriteOffsetY = this.data.spriteOffset?.y ?? 0;
@@ -1929,17 +1927,17 @@ export default class CanvasEffect extends PIXI.Container {
 			this.sprite.addChild(textSprite);
 		}
 
-		this.filters = [
-			new PIXI.filters.ColorMatrixFilter({
-				saturation: this.shouldShowFadedVersion ? -1 : 1,
-			}),
-			new PIXI.filters.AlphaFilter(
-				this.shouldShowFadedVersion
-					? game.settings.get(CONSTANTS.MODULE_NAME, "user-effect-opacity") /
-					100
-					: 1
-			),
-		];
+		if (this.shouldShowFadedVersion) {
+			this.filters = [
+				new PIXI.filters.ColorMatrixFilter({
+					saturation: -1,
+				}),
+				new PIXI.filters.AlphaFilter(
+					game.settings.get(CONSTANTS.MODULE_NAME, "user-effect-opacity") / 100
+				),
+			];
+		}
+		
 
 		this.updateElevation();
 	}
@@ -2825,6 +2823,9 @@ export default class CanvasEffect extends PIXI.Container {
 		);
 
 		for (let animation of oneShotAnimations) {
+			if (animation.target === 'alphaFilter') {
+				animation.target = 'sprite'
+			}
 			animation.target = foundry.utils.getProperty(this, animation.target);
 
 			if (!animation.target) continue;
@@ -2858,6 +2859,9 @@ export default class CanvasEffect extends PIXI.Container {
 		);
 
 		for (let animation of loopingAnimations) {
+			if (animation.target === 'alphaFilter') {
+				animation.target = 'sprite'
+			}
 			animation.target = foundry.utils.getProperty(this, animation.target);
 
 			if (!animation.target) continue;
@@ -2966,10 +2970,10 @@ export default class CanvasEffect extends PIXI.Container {
 			return;
 		}
 
-		this.alphaFilter.alpha = 0.0;
+		this.sprite.alpha = 0.0;
 
 		SequencerAnimationEngine.addAnimation(this.id, {
-			target: this.alphaFilter,
+			target: this.sprite,
 			propertyName: "alpha",
 			to: this.data.opacity,
 			duration: fadeIn.duration,
@@ -3034,7 +3038,7 @@ export default class CanvasEffect extends PIXI.Container {
 			: Math.max(this._totalDuration - fadeOut.duration + fadeOut.delay, 0);
 
 		SequencerAnimationEngine.addAnimation(this.id, {
-			target: this.alphaFilter,
+			target: this.sprite,
 			propertyName: "alpha",
 			to: 0.0,
 			duration: fadeOut.duration,


### PR DESCRIPTION
TL;DR: some optimizations.

This PR removes the alphaFilter of the effect sprite in favor of the direct alpha value. For backwards compatibility, animations will transform the `alphaFilter` target to the sprite directly, effectively targeting what was `sprite.alphaFilter.alpha` to `sprite.alpha`.

Furthermore, saturation and alpha filters for the "only displayed for other users" effect are only added when the effect really is only visible to other users.

All in all, this removes at least 3 draw calls per canvs effect and finally enables perfect batch rendering of canvas effects with #296!