### PR TITLE
Fix batch shader initialization order. Fixes #299

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -139,12 +139,14 @@ function initializeModule() {
   registerLayers();
   registerHotkeys();
   registerLibwrappers();
-  registerBatchShader();
 
   SequencerAboveUILayer.setup();
   SequencerEffectManager.setup();
-
 }
+
+Hooks.once('canvasInit', () => {
+  registerBatchShader();
+})
 
 Hooks.once("ready", async () => {
 


### PR DESCRIPTION
If the batch shader is initialized before creating the extra layer and the canvas initialization, resizing / rerendering of the layer fails because the batch shader initialization depends on the canvas being ready.

This means that currently, creation of the above screen space UI effects layer fails and effects that should be played there currently are not played at all.

This PR fixes the initialization order of the batch renderer, which solves this issue.