### PR TITLE
Fix Preloading of assets

### DIFF
--- a/src/modules/sequencer-preloader.js
+++ b/src/modules/sequencer-preloader.js
@@ -208,7 +208,7 @@ const SequencerPreloader = {
 
     return new Promise(async (resolve) => {
       let numFilesFailedToLoad = 0;
-      const loadingPromises = inSrcs.map(async (inSrcs) => {
+      const loadingPromises = inSrcs.map(async (src) => {
         const blob = await SequencerFileCache.loadFile(src, true);
         if (showProgressBar) LoadingBar.incrementProgress();
         if (!blob) {

--- a/src/modules/sequencer-preloader.js
+++ b/src/modules/sequencer-preloader.js
@@ -176,8 +176,8 @@ const SequencerPreloader = {
           }
           return src;
         })
-      )
-      .deepFlatten();
+        .deepFlatten()
+      );
 
     if (inSrcs.length >= 750) {
       lib.custom_warning(


### PR DESCRIPTION
This fixes two issues with the current preloading of assets:

1. The `src` for the preloading operation itself was undefined which made preloading just not work...
2. When checking for the amount of files to preload, in certain cases (mainly ranged attacks with distance scaling) the `inSrcs` value consists of an array of array of file paths, which makes the surrounding call to `make_array_unique` to check for unique paths not work as intended. By applying the deepFlatten operation before the unqiue call, the amount of files to preload is more accurately calculated.