### PR TITLE
Add tiling and ColorMatrix filter directly to sequencer effect shader

### DIFF
--- a/src/canvas-effects/canvas-effect.js
+++ b/src/canvas-effects/canvas-effect.js
@@ -11,6 +11,7 @@ import SequencerEffectManager from "../modules/sequencer-effect-manager.js";
 import { SequencerAboveUILayer } from "./effects-layer.js";
 import VisionSamplerShader from "../lib/filters/vision-mask-filter.js";
 import MaskFilter from "../lib/filters/mask-filter.js";
+import TilingSpriteMesh from "../lib/meshes/tiling-sprite-mesh.js";
 
 const hooksManager = {
 	_hooks: new Map(),
@@ -1598,10 +1599,12 @@ export default class CanvasEffect extends PIXI.Container {
 		}
 
 		if (this._isRangeFind && this.data.stretchTo && this.data.attachTo?.active) {
-			let spriteType = this.data.tilingTexture ? PIXI.TilingSprite : SpriteMesh;
-			this._relatedSprites[this._currentFilePath] = new spriteType(
+			this._relatedSprites[this._currentFilePath] = new TilingSpriteMesh(
 				this.texture,
-				this.data.xray ? null : VisionSamplerShader
+				{
+					isVisionMaskingEnabled: !this.data.xray,
+					tiling: !!this.data.tilingTexture
+				}
 			);
 			if (this.data.tint) {
 				this._relatedSprites[this._currentFilePath].tint = this.data.tint;
@@ -1612,13 +1615,13 @@ export default class CanvasEffect extends PIXI.Container {
 					if (filePath === this._currentFilePath) continue;
 
 					let texture = await this._file._getTexture(filePath);
-					let spriteType = this.data.tilingTexture
-						? PIXI.TilingSprite
-						: SpriteMesh;
-					let sprite = new spriteType(
+					let sprite = new TilingSpriteMesh(
 						texture,
-						this.data.xray ? null : VisionSamplerShader
-					);
+						{
+							isVisionMaskingEnabled: !this.data.xray,
+							tiling: !!this.data.tilingTexture
+						}
+					)
 					sprite.renderable = false;
 					this._relatedSprites[filePath] = sprite;
 				}
@@ -1817,22 +1820,20 @@ export default class CanvasEffect extends PIXI.Container {
 	_createSprite() {
 		this.renderable = false;
 
-		const args = [this.spriteSheet ? this.spriteSheet : PIXI.Texture.EMPTY];
-		if (
-			!this.data.xray &&
-			!this.spriteSheet &&
-			!this.data.screenSpace &&
-			!this.data.screenSpaceAboveUI
-		) {
-			args.push(VisionSamplerShader);
-		}
-
-		const spriteType = this.spriteSheet ? PIXI.AnimatedSprite : SpriteMesh;
-		const sprite = new spriteType(...args);
-		this.sprite = this.spriteContainer.addChild(sprite);
+		const texture = this.spriteSheet ? this.spriteSheet : PIXI.Texture.EMPTY;
+		const isVisionMaskingEnabled = 
+			!this.data.xray && 
+			!this.spriteSheet && 
+			!this.data.screenSpace && 
+			!this.data.screenSpaceAboveUI;
+		
+		const relatedSprites = Object.values(this._relatedSprites);
+		const spriteType = this.spriteSheet ? PIXI.AnimatedSprite : relatedSprites.length ? PIXI.Container : TilingSpriteMesh;
+		this.sprite = this.spriteContainer.addChild(new spriteType(texture));
+		this.sprite.isVisionMaskingEnabled = isVisionMaskingEnabled;
 		this.sprite.id = this.id + "-sprite";
 
-		Object.values(this._relatedSprites).forEach((sprite) => {
+		relatedSprites.forEach((sprite) => {
 			if (this.data.tint) {
 				sprite.tint = this.data.tint;
 			}
@@ -1872,7 +1873,19 @@ export default class CanvasEffect extends PIXI.Container {
 				const filter = new filters[filterData.className](filterData.data);
 				filter.id =
 					this.id + "-" + filterData.className + "-" + index.toString();
-				this.sprite.filters.push(filter);
+				if (filter instanceof PIXI.ColorMatrixFilter) {
+					if (textSprite || this.sprite instanceof PIXI.AnimatedSprite) {
+						this.sprite.filters.push(filter);
+					} else if (this.sprite.children.length > 0) {
+						this.sprite.children.forEach((child) => {
+							child.colorMatrixFilter = filter;
+						})
+					} else {
+						this.sprite.colorMatrixFilter = filter;	
+					}
+				} else {
+					this.sprite.filters.push(filter);
+				}
 				const filterKeyName = filterData.name || filterData.className;
 				this.effectFilters[filterKeyName] = filter;
 			}
@@ -1889,10 +1902,12 @@ export default class CanvasEffect extends PIXI.Container {
 
 		this.sprite.position.set(spriteOffsetX, spriteOffsetY);
 
-		this.sprite.anchor.set(
-			this.data.spriteAnchor?.x ?? 0.5,
-			this.data.spriteAnchor?.y ?? 0.5
-		);
+		if (this.sprite.constructor !== PIXI.Container) {
+			this.sprite.anchor.set(
+				this.data.spriteAnchor?.x ?? 0.5,
+				this.data.spriteAnchor?.y ?? 0.5
+			);
+		}
 
 		let spriteRotation = this.data.spriteRotation ?? 0;
 		if (this.data.randomSpriteRotation) {
@@ -2364,15 +2379,11 @@ export default class CanvasEffect extends PIXI.Container {
 			if (this._relatedSprites[filePath]) {
 				this._relatedSprites[filePath].renderable = true;
 			} else {
-				let sprite;
-				let spriteType = this.data.tilingTexture
-					? PIXI.TilingSprite
-					: SpriteMesh;
-				if (this.data.xray) {
-					sprite = new spriteType(texture);
-				} else {
-					sprite = new spriteType(texture, VisionSamplerShader);
-				}
+				const sprite = new TilingSpriteMesh(texture, {
+					isVisionMaskingEnabled: !this.data.xray,
+					tiling: !!this.data.tilingTexture
+				});
+				sprite.colorMatrixFilter = this.effectFilters['ColorMatrix']
 				this._relatedSprites[filePath] = sprite;
 				if (this.data.tint) {
 					sprite.tint = this.data.tint;
@@ -2411,12 +2422,12 @@ export default class CanvasEffect extends PIXI.Container {
 			if (this.data.tilingTexture) {
 				const scaleX = (this.data.scale.x ?? 1.0) * this.gridSizeDifference;
 				const scaleY = (this.data.scale.y ?? 1.0) * this.gridSizeDifference;
-				sprite.width = distance / scaleX;
-				sprite.height = texture.height;
 				sprite.scale.set(scaleX * this.flipX, scaleY * this.flipY);
+				sprite.width = distance;
+				sprite.height = texture.height * scaleY;
 
-				sprite.tileScale.x = this.data.tilingTexture.scale.x;
-				sprite.tileScale.y = this.data.tilingTexture.scale.y;
+				sprite.tileScale.x = this.data.tilingTexture.scale.x * scaleX;
+				sprite.tileScale.y = this.data.tilingTexture.scale.y * scaleY;
 
 				sprite.tilePosition = this.data.tilingTexture.position;
 			} else {

--- a/src/lib/filters/vision-mask-filter.js
+++ b/src/lib/filters/vision-mask-filter.js
@@ -1,6 +1,62 @@
+const tempMat = new PIXI.Matrix();
+const uvPoint = new PIXI.Point();
+
+class VisionSamplerShaderGenerator extends BatchShaderGenerator {
+	generateSampleSrc(maxTextures) {
+		let src = "\n\n";
+		for (let i = 0; i < maxTextures; i++) {
+			if (i > 0) {
+				src += "\nelse ";
+			}
+			if (i < maxTextures - 1) {
+				src += `if(vTextureId < ${i}.5)`;
+			}
+
+			src += "\n{";
+			src += `\n\tcolor = texture(uSamplers[${i}], coord, unclamped == coord ? 0.0f : -32.0f);`;
+			src += "\n}";
+		}
+
+		src += "\n";
+		src += "\n";
+
+		return src;
+	}
+}
+
+const emptyColorMatrix = new Uint8Array(20);
+
 export default class VisionSamplerShader extends BaseSamplerShader {
-	// /** @override */
 	static classPluginName = "sequencerVisionBatch";
+	static batchShaderGeneratorClass = VisionSamplerShaderGenerator;
+
+	static batchGeometry = [
+		{ id: "aVertexPosition", size: 2, normalized: false, type: PIXI.TYPES.FLOAT },
+		{ id: "aTextureCoord", size: 2, normalized: false, type: PIXI.TYPES.FLOAT },
+		{ id: "aClampOffset", size: 2, normalized: false, type: PIXI.TYPES.FLOAT },
+		{ id: "aClampFrame", size: 4, normalized: false, type: PIXI.TYPES.FLOAT },
+		{ id: "aMapCoord1", size: 3, normalized: false, type: PIXI.TYPES.FLOAT },
+		{ id: "aMapCoord2", size: 3, normalized: false, type: PIXI.TYPES.FLOAT },
+		{ id: "aMapCoord3", size: 3, normalized: false, type: PIXI.TYPES.FLOAT },
+		{ id: "aColor", size: 4, normalized: true, type: PIXI.TYPES.UNSIGNED_BYTE },
+		{ id: "aColorMatrixR", size: 4, normalized: false, type: PIXI.TYPES.FLOAT },
+		{ id: "aColorMatrixG", size: 4, normalized: false, type: PIXI.TYPES.FLOAT },
+		{ id: "aColorMatrixB", size: 4, normalized: false, type: PIXI.TYPES.FLOAT },
+		{ id: "aColorMatrixA", size: 4, normalized: false, type: PIXI.TYPES.FLOAT },
+		{ id: "aColorMatrixOffset", size: 4, normalized: false, type: PIXI.TYPES.FLOAT },
+		{ id: "aColorMatrixAlpha", size: 1, normalized: false, type: PIXI.TYPES.FLOAT },
+		{ id: "aShaderFlags", size: 1, normalized: false, type: PIXI.TYPES.UNSIGNED_SHORT },
+		{ id: "aTextureId", size: 1, normalized: false, type: PIXI.TYPES.UNSIGNED_SHORT },
+	];
+
+	static #SHADER_FLAGS = foundry.utils.BitMask.generateShaderBitMaskConstants([
+		"IS_TILING",
+		"IS_VISION_MASKING_ENABLED",
+		"IS_COLOR_MATRIX_ENABLED",
+	]);
+
+	/** @override */
+	static batchVertexSize = 42;
 
 	/** @override */
 	static reservedTextureUnits = 1; // We need a texture unit for the occlusion texture
@@ -9,58 +65,118 @@ export default class VisionSamplerShader extends BaseSamplerShader {
 	 * The batch vertex shader source.
 	 * @type {string}
 	 */
-	static batchVertexShader = `
-    #version 300 es
-    precision ${PIXI.settings.PRECISION_VERTEX} float;
-
-    uniform vec2 screenDimensions;
-
-    in vec2 aVertexPosition;
-    in vec2 aTextureCoord;
-    in vec4 aColor;
-    in float aTextureId;
-    uniform mat3 projectionMatrix;
-    uniform mat3 translationMatrix;
-    uniform vec4 tint;
-    out vec2 vTextureCoord;
-    out vec2 vVisionCoord;
-    flat out vec4 vColor;
-    flat out float vTextureId;
-
-    void main(void){
-      gl_Position = vec4((projectionMatrix * translationMatrix * vec3(aVertexPosition, 1.0)).xy, 0.0, 1.0);
-      vTextureCoord = aTextureCoord;
-      vTextureId = aTextureId;
-      vColor = aColor * tint;
-      vVisionCoord = aVertexPosition / screenDimensions;
-    }
-  `;
+	static batchVertexShader = /* glsl */ `#version 300 es
+	precision highp float;
+	
+	uniform vec2 screenDimensions;
+	uniform mat3 projectionMatrix;
+	uniform mat3 translationMatrix;
+	uniform vec4 tint;
+	
+	in vec2 aVertexPosition;
+	in vec2 aTextureCoord;
+	in vec2 aClampOffset;
+	in vec4 aClampFrame;
+	in vec3 aMapCoord1;
+	in vec3 aMapCoord2;
+	in vec3 aMapCoord3;
+	in vec4 aColor;
+	in vec4 aColorMatrixR;
+	in vec4 aColorMatrixG;
+	in vec4 aColorMatrixB;
+	in vec4 aColorMatrixA;
+	in vec4 aColorMatrixOffset;
+	in float aColorMatrixAlpha;
+	in float aShaderFlags;
+	in float aTextureId;
+	
+	out vec2 vTextureCoord;
+	out vec2 vVisionCoord;
+	flat out vec2 vClampOffset;
+	flat out vec4 vClampFrame;
+	flat out mat3 vMapCoord;
+	flat out vec4 vColor;
+	flat out mat4 vColorMatrix;
+	flat out vec4 vColorMatrixOffset;
+	flat out float vColorMatrixAlpha;
+	flat out uint vShaderFlags;
+	flat out float vTextureId;
+	
+	void main(void) {
+		gl_Position = vec4((projectionMatrix * translationMatrix * vec3(aVertexPosition, 1.0f)).xy, 0.0f, 1.0f);
+		vTextureCoord = aTextureCoord;
+		vVisionCoord = aVertexPosition / screenDimensions;
+		vColor = aColor * tint;
+		vClampOffset = aClampOffset;
+		vClampFrame = aClampFrame;
+		vMapCoord = mat3(aMapCoord1, aMapCoord2, aMapCoord3);
+		vColorMatrix = mat4(aColorMatrixR, aColorMatrixG, aColorMatrixB, aColorMatrixA);
+		vColorMatrixOffset = aColorMatrixOffset;
+		vColorMatrixAlpha = aColorMatrixAlpha;
+		vShaderFlags = uint(aShaderFlags);
+		vTextureId = aTextureId;
+	}
+	`;
 
 	/**
 	 * The batch fragment shader source.
 	 * @type {string}
 	 */
-	static batchFragmentShader = `
-    #version 300 es
-    precision ${PIXI.settings.PRECISION_FRAGMENT} float;
-    in vec2 vTextureCoord;
-    flat in vec4 vColor;
-    flat in float vTextureId;
-    in vec2 vVisionCoord;
-    uniform bool enableVisionMasking;
-    uniform sampler2D visionMaskTexture;
-    uniform sampler2D uSamplers[%count%];
-    out vec4 fragColor;
+	static batchFragmentShader = /* glsl */ `#version 300 es
+	precision mediump float;
 
-    #define texture2D texture
+	in vec2 vTextureCoord;
+	in vec2 vVisionCoord;
+	flat in float vTextureId;
+	flat in vec4 vColor;
+	flat in mat3 vMapCoord;
+	flat in uint vShaderFlags;
+	flat in vec2 vClampOffset;
+	flat in vec4 vClampFrame;
+	flat in mat4 vColorMatrix;
+	flat in vec4 vColorMatrixOffset;
+	flat in float vColorMatrixAlpha;
 
-    void main(void){
-      float mask = enableVisionMasking ? texture2D(visionMaskTexture, vVisionCoord).r : 1.0;
-      vec4 color;
-      %forloop%
-      fragColor = color * vColor * mask;
-    }
-  `;
+	uniform bool enableVisionMasking;
+	uniform sampler2D visionMaskTexture;
+	uniform sampler2D uSamplers[%count%];
+	out vec4 fragColor;
+
+	${VisionSamplerShader.#SHADER_FLAGS}
+
+	void main(void){
+		bool isTilingEnabled = ((vShaderFlags & IS_TILING) == IS_TILING);
+		bool isVisionMaskingEnabled = ((vShaderFlags & IS_VISION_MASKING_ENABLED) == IS_VISION_MASKING_ENABLED);
+		bool isColorMatrixEnabled = ((vShaderFlags & IS_COLOR_MATRIX_ENABLED) == IS_COLOR_MATRIX_ENABLED);
+
+		vec2 coord = vTextureCoord;
+		vec2 unclamped;
+		if (isTilingEnabled) {
+			coord = coord + ceil(vClampOffset - coord);
+			coord = (vMapCoord * vec3(coord, 1.0)).xy;
+			unclamped = coord;
+			coord = clamp(coord, vClampFrame.xy, vClampFrame.zw);
+		} else {
+			unclamped = coord;
+	  }
+	  float mask = isVisionMaskingEnabled && enableVisionMasking ? texture(visionMaskTexture, vVisionCoord).r : 1.0;
+
+	  vec4 color;
+	  %forloop%
+
+		if (isColorMatrixEnabled && vColorMatrixAlpha > 0.0) {
+			if (color.a > 0.0) {
+	      color.rgb /= color.a;
+	    }
+			vec4 result = color * vColorMatrix + vColorMatrixOffset;
+
+			vec3 rgb = mix(color.rgb, result.rgb, vColorMatrixAlpha);
+			rgb *= result.a;
+			color = vec4(rgb, result.a);
+	  }
+	  fragColor = color * mask;
+	}	
+	`;
 
 	/** @override */
 	static batchDefaultUniforms(maxTex) {
@@ -76,5 +192,110 @@ export default class VisionSamplerShader extends BaseSamplerShader {
 		uniforms.screenDimensions = canvas.screenDimensions;
 		uniforms.enableVisionMasking = canvas?.visibility?.visible ?? canvas?.effects?.visibility?.visible ?? true;
 		batchRenderer.renderer.texture.bind(canvas.masks.vision.renderTexture, uniforms.visionMaskTexture);
+	}
+
+	/** @override */
+	static _packInterleavedGeometry(element, attributeBuffer, indexBuffer, aIndex, iIndex) {
+		const { float32View, uint32View, uint16View } = attributeBuffer;
+
+		/** @type {import("../pixi/TilingSpriteMesh").default} */
+		const mesh = element.object;
+		// Write indices into buffer
+		const packedVertices = aIndex / this.vertexSize;
+		const indices = element.indices;
+		for (let i = 0; i < indices.length; i++) {
+			indexBuffer[iIndex++] = packedVertices + indices[i];
+		}
+
+		// Prepare attributes
+		const vertexData = element.vertexData;
+		let uvs = element.uvs;
+		const alpha = Math.min(element.worldAlpha, 1.0);
+		const baseTexture = element._texture.baseTexture;
+		const argb = PIXI.Color.shared.setValue(element._tintRGB).toPremultiplied(alpha, baseTexture.alphaMode > 0);
+		const textureId = element._texture.baseTexture._batchLocation;
+		const mapCoord = mesh.uvMatrix.mapCoord.toArray(true);
+		let clampFrame = mesh.uvMatrix.uClampFrame;
+		let clampOffset = mesh.uvMatrix.uClampOffset;
+		if (mesh.tiling) {
+			const tex = element._texture;
+			const w = tex.width;
+			const h = tex.height;
+			const W = mesh.width;
+			const H = mesh.height;
+			const lt = mesh.tileTransform.localTransform;
+			tempMat.set((lt.a * w) / W, (lt.b * w) / H, (lt.c * h) / W, (lt.d * h) / H, lt.tx / W, lt.ty / H);
+
+			const anchorX = mesh.uvRespectAnchor ? mesh.anchor.x : 0;
+			const anchorY = mesh.uvRespectAnchor ? mesh.anchor.y : 0;
+
+			uvs[0] = uvs[6] = -anchorX;
+			uvs[1] = uvs[3] = -anchorY;
+			uvs[2] = uvs[4] = 1.0 - anchorX;
+			uvs[5] = uvs[7] = 1.0 - anchorY;
+		}
+
+		// Write attributes into buffer
+		const vertexSize = this.vertexSize;
+		const colorMatrixArray = mesh.colorMatrixFilter?.matrix ?? emptyColorMatrix;
+		const colorMatrixAlpha = mesh.colorMatrixFilter?.alpha ?? 1;
+		for (let i = 0, j = 0; i < vertexData.length; i += 2, j += vertexSize) {
+			uvPoint.set(uvs[i], uvs[i + 1]);
+			if (mesh.tiling) {
+				tempMat.applyInverse(uvPoint, uvPoint);
+			}
+			let k = aIndex + j;
+			float32View[k++] = vertexData[i];
+			float32View[k++] = vertexData[i + 1];
+			float32View[k++] = uvPoint.x;
+			float32View[k++] = uvPoint.y;
+			float32View[k++] = clampOffset[0];
+			float32View[k++] = clampOffset[1];
+			float32View[k++] = clampFrame[0];
+			float32View[k++] = clampFrame[1];
+			float32View[k++] = clampFrame[2];
+			float32View[k++] = clampFrame[3];
+			float32View[k++] = mapCoord[0];
+			float32View[k++] = mapCoord[1];
+			float32View[k++] = mapCoord[2];
+			float32View[k++] = mapCoord[3];
+			float32View[k++] = mapCoord[4];
+			float32View[k++] = mapCoord[5];
+			float32View[k++] = mapCoord[6];
+			float32View[k++] = mapCoord[7];
+			float32View[k++] = mapCoord[8];
+			uint32View[k++] = argb;
+
+			float32View[k++] = colorMatrixArray[0];
+			float32View[k++] = colorMatrixArray[1];
+			float32View[k++] = colorMatrixArray[2];
+			float32View[k++] = colorMatrixArray[3];
+
+			float32View[k++] = colorMatrixArray[5];
+			float32View[k++] = colorMatrixArray[6];
+			float32View[k++] = colorMatrixArray[7];
+			float32View[k++] = colorMatrixArray[8];
+
+			float32View[k++] = colorMatrixArray[10];
+			float32View[k++] = colorMatrixArray[11];
+			float32View[k++] = colorMatrixArray[12];
+			float32View[k++] = colorMatrixArray[13];
+
+			float32View[k++] = colorMatrixArray[15];
+			float32View[k++] = colorMatrixArray[16];
+			float32View[k++] = colorMatrixArray[17];
+			float32View[k++] = colorMatrixArray[18];
+
+			float32View[k++] = colorMatrixArray[4];
+			float32View[k++] = colorMatrixArray[9];
+			float32View[k++] = colorMatrixArray[14];
+			float32View[k++] = colorMatrixArray[19];
+
+			float32View[k++] = colorMatrixAlpha;
+
+			k <<= 1;
+			uint16View[k++] = mesh.shaderFlags.valueOf();
+			uint16View[k++] = textureId;
+		}
 	}
 }

--- a/src/lib/meshes/tiling-sprite-mesh.js
+++ b/src/lib/meshes/tiling-sprite-mesh.js
@@ -1,0 +1,110 @@
+import VisionSamplerShader from "../filters/vision-mask-filter.js";
+
+/**
+ * Extends SpriteMesh to allow for tiling of sprites
+ */
+export default class TilingSpriteMesh extends SpriteMesh {
+	/** @type {PIXI.Transform} */
+	tileTransform;
+
+	/** @type {PIXI.TextureMatrix} */
+	uvMatrix;
+
+	/** @type {PIXI.ColorMatrixFilter} */
+	#colorMatrixFilter;
+
+	shaderFlags = new foundry.utils.BitMask({
+		isTiling: false,
+		isVisionMaskingEnabled: true,
+		isColorMatrixEnabled: false,
+	});
+
+	/**
+	 * @param {PIXI.Texture} texture - The {@link PIXI.Texture} bound to this mesh
+	 * @param {object} [options = {}]
+	 * @property {typeof BaseSamplerShader} options.shaderClassader Shader class used by this sprite mesh.
+	 * @property {boolean} options.tiling Shader class used by this sprite mesh.
+	 * @property {boolean} options.isVisionMaskingEnabled Shader class used by this sprite mesh.
+	 */
+	constructor(texture, { shaderClass = VisionSamplerShader, tiling = false, isVisionMaskingEnabled = true } = {}) {
+		super(texture, shaderClass);
+		this.tileTransform = new PIXI.Transform();
+		this.tiling = tiling;
+		this.isVisionMaskingEnabled = isVisionMaskingEnabled;
+		this.uvMatrix = this.texture.uvMatrix || new PIXI.TextureMatrix(texture);
+	}
+
+	get tiling() {
+		return this.shaderFlags.hasState('isTiling')
+	}
+	/**
+	 * @param {boolean} value
+	 */
+	set tiling(value) {
+		this.shaderFlags.toggleState('isTiling', value)
+	}
+
+	
+	get isVisionMaskingEnabled() {
+		return this.shaderFlags.hasState('isVisionMaskingEnabled')
+	}
+	/**
+	 * @param {boolean} value
+	 */
+	set isVisionMaskingEnabled(value) {
+		this.shaderFlags.toggleState('isVisionMaskingEnabled', value)
+	}
+
+
+	/**
+	 * @param {PIXI.ColorMatrixFilter | null} value
+	 */
+	set colorMatrixFilter(value) {
+		this.shaderFlags.toggleState('isColorMatrixEnabled', value != null)
+		this.#colorMatrixFilter = value;
+	}
+	get colorMatrixFilter() {
+		return this.#colorMatrixFilter;
+	}
+
+	/** The scaling of the image that is being tiled. */
+	get tileScale() {
+		return this.tileTransform.scale;
+	}
+
+	set tileScale(value) {
+		this.tileTransform.scale.copyFrom(value);
+	}
+
+	/** The offset of the image that is being tiled. */
+	get tilePosition() {
+		return this.tileTransform.position;
+	}
+
+	set tilePosition(value) {
+		this.tileTransform.position.copyFrom(value);
+	}
+
+	_onTextureUpdate() {
+		super._onTextureUpdate();
+		if (this.uvMatrix) {
+			this.uvMatrix.texture = this._texture;
+		}
+	}
+
+	/**
+	 * Renders the object using the WebGL renderer
+	 * @param renderer - The renderer
+	 */
+	_render(renderer) {
+		this.uvMatrix.update();
+		this.tileTransform.updateLocalTransform();
+		super._render(renderer);
+	}
+
+	destroy() {
+		super.destroy();
+		this.tileTransform = null;
+		this.uvMatrix = null;
+	}
+}


### PR DESCRIPTION
This PR introduces a new class `TilingSpriteMesh` that builds upon the regular foundry spriteMesh to bring tiling capabilities without having to use `PIXI.TilingSprite`. This allows tiling texture effects and regular effects to use the same mesh and shader (which is now modified to include rendering of tiling textures).
This makes the code a little bit nicer, but more importantly allows for batching across video-based effects and tiling effects!
In this test scene with one tiling texture for every 2 regular effects, this increases the performance quite dramatically.

https://github.com/user-attachments/assets/26890719-48d3-4942-8d56-d9ae9d4dedf1

https://github.com/user-attachments/assets/d2001b2e-7e0d-47ff-8afa-ae44f8b11ed6



But why stop there... There is one filter that is very often used to modify existing effects, which is color matrix. Makes sense, as it allows for all sorts of color-correction and manipulation. Blue, purple or black fireball? Just one color matrix filter awway!
The issue with color matrix as with all filters previously was, that it breaks batching completely and also requires rendering the texture to one extra buffer before applying the effect (essentially re-rendering the effect again with color correction applied)
All in all, this was quite the performance killer if used in persisted effects for example.
Good news is, that the filter can be inlined into the existing shader! And because of the previous work, this includes tiling textures and regular video effects!


https://github.com/user-attachments/assets/5e2cd8ac-203b-4026-90cf-98fc072a6f59


https://github.com/user-attachments/assets/588a3f65-e43d-4ff4-8fda-2fa3237aed94



As a final note, this now also allows tilingTextures to respect the vision masking:
<img width="500" alt="tiling vision masking" src="https://github.com/user-attachments/assets/90116892-dd0c-4529-a9dd-383b32f2338a">

