### PR TITLE
Update thenDo types

### DIFF
--- a/typings/types.d.ts
+++ b/typings/types.d.ts
@@ -123,7 +123,7 @@ declare class CoreMethods {
   /**
    * Creates a section that will run a function.
    */
-  thenDo(inFunc: () => void | (() => Promise<void>)): Sequence;
+  thenDo(inFunc: () => void | Promise<void>): Sequence;
 
   /**
    * Creates a section that will run a macro based on a name, id, UUID, or a direct reference to a macro.


### PR DESCRIPTION
I believe this was a typo as before the change the types basically said "either return void or a function that returns a promise of void." The documentation also states it should be just be a void-returning function, async or not.

![Code_AFCSXwXQiT](https://github.com/user-attachments/assets/f258e159-8e46-4878-8053-6ac2f3e5e26f)
