### PR TITLE
Fix batch shader initialization.

### DIFF
--- a/src/lib/filters/vision-mask-filter.js
+++ b/src/lib/filters/vision-mask-filter.js
@@ -298,4 +298,81 @@ export default class VisionSamplerShader extends BaseSamplerShader {
 			uint16View[k++] = textureId;
 		}
 	}
+
+	// need to override createPlugin as canvas.performance is not defined in foundry when
+	// we need it to be
+	static createPlugin() {
+    const shaderClass = this;
+    const geometryClass = Array.isArray(shaderClass.batchGeometry)
+      ? class BatchGeometry extends PIXI.Geometry {
+        constructor(_static=false) {
+          super();
+          this._buffer = new PIXI.Buffer(null, _static, false);
+          this._indexBuffer = new PIXI.Buffer(null, _static, true);
+          for ( const {id, size, normalized, type} of shaderClass.batchGeometry ) {
+            this.addAttribute(id, this._buffer, size, normalized, type);
+          }
+          this.addIndex(this._indexBuffer);
+        }
+      } : shaderClass.batchGeometry;
+    return class BatchPlugin extends shaderClass.batchRendererClass {
+
+      /** @override */
+      static get shaderGeneratorClass() {
+        return shaderClass.batchShaderGeneratorClass;
+      }
+
+      /* ---------------------------------------- */
+
+      /** @override */
+      static get defaultVertexSrc() {
+        return shaderClass.batchVertexShader;
+      }
+
+      /* ---------------------------------------- */
+
+      /** @override */
+      static get defaultFragmentTemplate() {
+        return shaderClass.batchFragmentShader;
+      }
+
+      /* ---------------------------------------- */
+
+      /** @override */
+      static get defaultUniforms() {
+        return shaderClass.batchDefaultUniforms;
+      }
+
+      /* ---------------------------------------- */
+
+      /**
+       * The batch plugin constructor.
+       * @param {PIXI.Renderer} renderer    The renderer
+       */
+      constructor(renderer) {
+        super(renderer);
+        this.geometryClass = geometryClass;
+        this.vertexSize = shaderClass.batchVertexSize;
+        this.reservedTextureUnits = shaderClass.reservedTextureUnits;
+        this._packInterleavedGeometry = shaderClass._packInterleavedGeometry;
+        this._preRenderBatch = shaderClass._preRenderBatch;
+      }
+
+      /* ---------------------------------------- */
+
+      /** @inheritdoc */
+      setShaderGenerator(options) {
+        // if ( !canvas.performance ) return;
+        super.setShaderGenerator(options);
+      }
+
+      /* ---------------------------------------- */
+
+      /** @inheritdoc */
+      contextChange() {
+        this.shaderGenerator = null;
+        super.contextChange();
+      }
+    };
+  }
 }

--- a/src/module.js
+++ b/src/module.js
@@ -141,14 +141,11 @@ function initializeModule() {
   registerLayers();
   registerHotkeys();
   registerLibwrappers();
-
-  SequencerAboveUILayer.setup();
-  SequencerEffectManager.setup();
-}
-
-Hooks.once('canvasConfig', () => {
   registerBatchShader();
-})
+
+  SequencerEffectManager.setup();
+  SequencerAboveUILayer.setup();
+}
 
 Hooks.once("ready", async () => {
 


### PR DESCRIPTION
The `createPlugin` code is copied from the original `BaseSamplerShader` foundry class.
Reason we need to override it here is due to the way foundry initialized the canvas and the hooks at our disposal.
The shaders "owned" by foundry are initialized directly in the canvas init function. Sadly, if we init it in the regular "init" hook, settings are not yet defined and `canvas.performance`, which the default implementation checks to essentially verify that a canvas is available, is simply not set yet.

If we init it in a canvasReady or other later hook, the "prerender" functions are called first and break because they expect the batch shaders to all be registered...

Only way around this that I could see was to skip the check if a canvas is available and register the shader as a PIXI extension either way.

This does not throw errors in case the canvas is disabled. It seems to be just a performance optimization for the "no canvas" codepath.

This fixes #317 