### PR TITLE
Minor corrections/improvements to crosshairs

### DIFF
--- a/src/modules/sequencer-crosshair/CrosshairsDocument.js
+++ b/src/modules/sequencer-crosshair/CrosshairsDocument.js
@@ -28,7 +28,7 @@ export default class CrosshairsDocument extends MeasuredTemplateDocument {
 	}
 
 	static get defaultConfig() {
-		return foundry.utils.deepClone({
+		return {
 			gridHighlight: true,
 			icon: {
 				texture: "",
@@ -58,7 +58,7 @@ export default class CrosshairsDocument extends MeasuredTemplateDocument {
 				wallBehavior: CONSTANTS.PLACEMENT_RESTRICTIONS.ANYWHERE
 			},
 			lockManualRotation: false
-		})
+		};
 	};
 
 	getOrientation() {

--- a/src/modules/sequencer-crosshair/TokenCrosshairsDocument.js
+++ b/src/modules/sequencer-crosshair/TokenCrosshairsDocument.js
@@ -40,7 +40,7 @@ export default class TokenCrosshairsDocument extends CrosshairsDocument {
 	}
 
 	static get defaultConfig() {
-		return foundry.utils.deepClone(foundry.utils.mergeObject(super.defaultConfig, {
+		return foundry.utils.mergeObject(super.defaultConfig, {
 			gridHighlight: false,
 			snap: {
 				position: CONST.GRID_SNAPPING_MODES.VERTEX
@@ -50,7 +50,7 @@ export default class TokenCrosshairsDocument extends CrosshairsDocument {
 			},
 			lockDrag: true,
 			alpha: 0.5
-		}));
+		});
 	}
 
 	static get placeableClass() {

--- a/src/sections/crosshair.js
+++ b/src/sections/crosshair.js
@@ -216,7 +216,7 @@ export default class CrosshairSection extends Section {
 	 * Causes the crosshair to spawn a measurable template identical to the crosshair
 	 */
 	persist(inBool = true) {
-		if (typeof inBool !== "boolean") throw this.sequence._customError(this, "persist", "inBool must be of type number");
+		if (typeof inBool !== "boolean") throw this.sequence._customError(this, "persist", "inBool must be of type boolean");
 		this._persist = inBool;
 		return this;
 	}

--- a/typings/types.d.ts
+++ b/typings/types.d.ts
@@ -83,7 +83,7 @@ type CrosshairsData = {
   snap: {
     position: SnappingOptions,
     size: SnappingOptions,
-    angle: number
+    direction: number
   },
 	lockDrag: boolean,
   distanceMin: null | number,

--- a/typings/types.d.ts
+++ b/typings/types.d.ts
@@ -75,38 +75,39 @@ type TemplateData = {
 }
 
 type CrosshairsData = {
-  gridHighlight: boolean,
-  icon: {
-    texture: string,
-	  borderVisible: boolean
-  },
-  snap: {
-    position: number,
-    size: number,
-    direction: number
-  },
-	lockDrag: boolean,
-  distanceMin: null | number,
-  distanceMax: null | number,
-  label: {
-    text: string,
-    dx: number,
-    dy: number,
-  },
-  location: {
-    obj: null | VisibleFoundryTypes,
-	  limitMinRange: number | null,
-	  limitMaxRange: number | null,
-	  showRange: boolean,
-    lockToEdge: boolean,
-	  lockToEdgeDirection: boolean,
-	  offset: {
-			x: number,
-		  y: number
-		}
-  },
-  lockManualRotation: boolean,
-  textureTile: number,
+	gridHighlight: boolean;
+	icon: {
+		texture: string;
+		borderVisible: boolean;
+	};
+	snap: {
+		position: number;
+		size: number;
+		direction: number;
+	};
+	lockDrag: boolean;
+	distanceMin: null | number;
+	distanceMax: null | number;
+	label: {
+		text: string;
+		dx: number;
+		dy: number;
+	};
+	location: {
+		obj: null | VisibleFoundryTypes;
+		limitMinRange: number | null;
+		limitMaxRange: number | null;
+		showRange: boolean;
+		lockToEdge: boolean;
+		lockToEdgeDirection: boolean;
+		offset: {
+			x: number;
+			y: number;
+		};
+		wallBehavior: string;
+	};
+	lockManualRotation: boolean;
+	textureTile: number;
 };
 
 declare interface CrosshairData extends
@@ -1187,7 +1188,8 @@ declare abstract class CrosshairSection {
 		offset?: {
 			x?: number;
 			y?: number;
-		}
+		};
+		wallBehavior: string;
 	}): this;
 
 	/**

--- a/typings/types.d.ts
+++ b/typings/types.d.ts
@@ -81,8 +81,8 @@ type CrosshairsData = {
 	  borderVisible: boolean
   },
   snap: {
-    position: SnappingOptions,
-    size: SnappingOptions,
+    position: number,
+    size: number,
     direction: number
   },
 	lockDrag: boolean,

--- a/typings/types.d.ts
+++ b/typings/types.d.ts
@@ -100,7 +100,6 @@ type CrosshairsData = {
 	  showRange: boolean,
     lockToEdge: boolean,
 	  lockToEdgeDirection: boolean,
-	  lockOffsetDistance: number | null,
 	  offset: {
 			x: number,
 		  y: number


### PR DESCRIPTION
Just some small fixes I've found during my work for PF2e Graphics:
- Typing errors:
  - `CrosshairsData.snap.angle` should be `.direction`
  - `CrosshairsData.snap.position` and `.size` should be numbers. `SnappingOptions` or `CONST.GRID_SNAPPING_MODES` lets you map from human-readable strings to the appropriate number, but a number is still what's ultimately desired. Trying to be smart with enums seems to cause problems down the line for TS projects depending on Sequencer (e.g. PF2e Graphics), so I think that'll have to wait for a putative TS rewrite sometime in the distant future 😏
  - `CrosshairsData.location.lockOffsetDistance` was removed because it doesn't appear to exist in the code?
  - `CrosshairsData.location.wallBehavior` wasn't defined (also same thing applies regarding enums as above)
- The type-guard for `CrosshairSection.persist(inBool: boolean)` returns an error message saying that `inBool` should be a number; it should instead of course be a boolean
- There's a couple cases of `foundry.utils.deepClone()` in the crosshairs code that seem redundant. Specifically, you shouldn't need to deep-clone a non-variable object-literal that's being returned from a function, since the function should instantiate a new object each time it's called.

The diff should all be simple enough to easily inspect 👍