### PR TITLE
Correctly set `renderable` property on ui layer when adding children

### DIFF
--- a/src/canvas-effects/effects-layer.js
+++ b/src/canvas-effects/effects-layer.js
@@ -473,9 +473,7 @@ export class SequencerAboveUILayer {
   static addChild(...args) {
 		const layer = this.getLayer();
     const result = layer.addChild(...args);
-		if (layer.app?.stage) {
-			layer.renderable = layer.children.length > 0;
-		}
+		layer.renderable = layer.children.length > 0;
     return result;
   }
 


### PR DESCRIPTION
When fixinig the fallback code for the above UI layer I forgot to update one line that activates the layer when children are added...

Apparently I only tested the fallback path then. I now tested that both paths work. Playing on the above UI layer if it is enabled and also correctly playing on the regular UI layer if the above UI layer is disabled.