### PR TITLE
Fix for Crosshair.collect

### DIFF
--- a/src/modules/sequencer-crosshair/sequencer-crosshair.js
+++ b/src/modules/sequencer-crosshair/sequencer-crosshair.js
@@ -80,14 +80,43 @@ export default class Crosshair {
 		return Array.isArray(types) ? result : result[types];
 
 	}
-
-	static containsCenter(placeable, crosshair) {
-		const calcDistance = (A, B) => {
-			return Math.hypot(A.x - B.x, A.y - B.y);
-		};
-
-		const distance = calcDistance(placeable.center, crosshair);
-		return distance <= crosshair.distance * crosshair.parent.grid.size;
+	
+	static containsCenter(placeable, crosshair){
+		if (!crosshair) return;
+		const crosshairToShape = (crosshair) =>{
+			let shape;
+		
+			if(crosshair.t === CONST.MEASURED_TEMPLATE_TYPES.CIRCLE){
+				const ratio = canvas.scene.dimensions.distancePixels;
+				shape = new PIXI.Circle(crosshair.x, crosshair.y, crosshair.distance * ratio);
+				return shape;
+			}
+		
+			if(crosshair.t === CONST.MEASURED_TEMPLATE_TYPES.RECTANGLE){
+				shape = new PIXI.Rectangle(crosshair.x, crosshair.y, crosshair.width, crosshair.height);
+				return shape;
+			}
+		
+			if(crosshair.t === CONST.MEASURED_TEMPLATE_TYPES.CONE || crosshair.t === CONST.MEASURED_TEMPLATE_TYPES.RAY){ //  CONE or RAY
+				let template;
+				
+				if (crosshair.t === CONST.MEASURED_TEMPLATE_TYPES.CONE){
+					template = MeasuredTemplate.getConeShape(crosshair.distance, crosshair.direction, crosshair.angle)
+				}
+				else{
+					template = MeasuredTemplate.getRayShape(crosshair.distance, crosshair.direction,crosshair.width)
+				}
+		
+				shape = new PIXI.Polygon(template.points.map((p,i) => {
+					if(i%2 === 0) return p+crosshair.x;
+					else return p+crosshair.y;
+				}));
+				return shape;
+			}
+			if(!shape) return;
+		}
+		const shape = crosshairToShape(crosshair);
+		return shape.contains(placeable.center.x, placeable.center.y)
 	}
 
 }


### PR DESCRIPTION
There was a mix-up for the crosshair.distance being in feet instead of grid units so targets outside of the crosshair were being picked up. 
Also, the calculations were not taking crosshair type into account ("circle", "cone"...etc)
The code was written mainly by Freeze and modified by @thatlonelybugbear, @GhostHyena and some tweaks from myself to try and follow your previously implemented methods as best I could 😅 
Not extensively tested, especially with other placeables than tokens but I hope that helps.
EDIT: Freeze wasn't referring to the right person, lol