### PR TITLE
Some spritesheet fixes

### DIFF
--- a/src/canvas-effects/sequencer-sprite-manager.js
+++ b/src/canvas-effects/sequencer-sprite-manager.js
@@ -679,9 +679,9 @@ export class SequencerSpriteManager extends PIXI.Container {
 			const prev = this.managedSprite;
 			view.tint = prev.tint;
 			view.anchor.copyFrom(prev.anchor);
+			view.scale.copyFrom(prev.scale);
 			view.width = prev.width;
 			view.height = prev.height;
-			view.scale.copyFrom(prev.scale);
 			view.tileScale.copyFrom(prev.tileScale);
 			view.tilePosition.copyFrom(prev.tilePosition);
 			view.pivot.copyFrom(prev.pivot);

--- a/src/lib/meshes/AnimatedSpriteMesh.js
+++ b/src/lib/meshes/AnimatedSpriteMesh.js
@@ -128,11 +128,12 @@ export default class AnimatedSpriteMesh extends TilingSpriteMesh {
 			return;
 		}
 		this._previousFrame = currentFrame;
-		this.texture = this._textures[currentFrame];
+		this._texture = this._textures[currentFrame];
 		this._textureID = -1;
 		this._textureTrimmedID = -1;
 		this._cachedTint = [1, 1, 1, 1];
-		this.updateUvs();
+		this.uvs.set(this._texture._uvs.uvsFloat32);
+		
 		if (this.updateAnchor) {
 			this._anchor.copyFrom(this._texture.defaultAnchor);
 		}

--- a/src/lib/spritesheets/FramePacker.js
+++ b/src/lib/spritesheets/FramePacker.js
@@ -125,7 +125,7 @@ export class FramePacker {
 		 * @param {number} scaleFactor
 		 * @return {Promise<{buffer: Uint8Array, size: Size}>}
 		 */
-		async function getScaledImageBuffer(buffer, sourceSize, scaleFactor) {
+		const getScaledImageBuffer = async (buffer, sourceSize, scaleFactor) => {
 			if (scaleFactor === 1) {
 				return { buffer, size: sourceSize };
 			}

--- a/src/modules/sequencer-file-cache.js
+++ b/src/modules/sequencer-file-cache.js
@@ -163,7 +163,7 @@ const SequencerFileCache = {
       )
       return undefined
     }
-    return result.spritesheet
+    return result?.spritesheet
   },
 
   registerSpritesheet(inSrc, inSpriteSheet) {
@@ -182,7 +182,6 @@ const SequencerFileCache = {
    */
   async unloadSpritesheet(inSrc) {
     const existingSheetRef = this._spritesheets.get(inSrc)
-    this._generateSpritesheetJobs.delete(inSrc)
     if (!existingSheetRef) {
       console.error("trying to unlaod spritesheet that was not loaded:", inSrc)
       return
@@ -191,6 +190,7 @@ const SequencerFileCache = {
     if (existingSheetRef[1] > 0) {
       return
     }
+    this._generateSpritesheetJobs.delete(inSrc)
     this._spritesheets.delete(inSrc)
     /** @type {PIXI.Spritesheet} */
     const sheet = existingSheetRef[0]


### PR DESCRIPTION
This fixes multiple errors with the current implementation of spritesheets:

1. `this` value being undefined in FramePacker.js under certain circumstances when creating scaled spritesheets for effects.
2. `result.spritesheet` accessing `spritesheet` of undefined value in sequencer-file-cache.js when a spritesheet job is accessed after the same job previously could not generate a spritesheet for any reason.
3. bidrectionally attached effects using spritesheets flickering between the actual distance between attached source and target and initial source/target distance after the related effectd for the currently active distance was first displayed
4. Effects jumping in size for one frame when switching to another related effect (for example because of distance scaling for effects attached to both a source and target)