### PR TITLE
Fix scaling of spritesheets and alpha trimming

### DIFF
--- a/src/lib/spritesheets/decodeWorker.js
+++ b/src/lib/spritesheets/decodeWorker.js
@@ -74,12 +74,6 @@ async function decodeWebm(buffer, minimumScale, id) {
 			return errorResponse("File has no Video Tracks");
 		}
 		const metadata = videoTrack.getMetadata();
-		// if (metadata.codecSize.width >= 1000 && metadata.codecSize.height >= 1000 && videoTrack.frames.length > 80) {
-		// 	const w = metadata.codecSize.width;
-		// 	const h = metadata.codecSize.height;
-		// 	const frameCount = videoTrack.frames.length;
-		// 	return errorResponse(`Video file is too large for ${id}: ${frameCount} * ${w}x${h}px`);
-		// }
 		const codec = videoTrack.getCodec();
 		let frames, alphaFrames;
 		try {


### PR DESCRIPTION
Changes to `src/lib/spritesheets/decodeWorker.js` are just cleanup.
Many other changes were cleanup or naming changes.

Rectified mistakes were:

* The scaled buffer and sizing rectangle after resizing was not actually passed on as imageBuffer (line 172, 173).
* when trimming the images, the first pixel data (red channel) was read instead of the alpha channel.