### PR TITLE
Prefer larger spritesheets when scaling

### DIFF
--- a/src/lib/spritesheets/FramePacker.js
+++ b/src/lib/spritesheets/FramePacker.js
@@ -58,7 +58,7 @@ export class FramePacker {
 			frames.map((frame, idx) => this.#combineFrames(frame, alphaFrames[idx], idx))
 		);
 
-		const packedData = await this.#packScaledFrames(combinedFrames, minimumScale);
+		const packedData = await this.scaleAndPackFrames(combinedFrames, minimumScale);
 		if (!packedData) {
 			return;
 		}
@@ -116,7 +116,7 @@ export class FramePacker {
 	 * @param {number} minimumScale
 	 * @return {Promise<PackedFramesContainer | undefined>}
 	 */
-	async #packScaledFrames(frameData, minimumScale) {
+	async scaleAndPackFrames(frameData, minimumScale) {
 		let scale = 1;
 
 		/**
@@ -179,7 +179,7 @@ export class FramePacker {
 			spriteWidth = Math.ceil(w / 4) * 4;
 			spriteHeight = Math.ceil(h / 4) * 4;
 			if (Math.max(spriteHeight, spriteWidth) > 8192) {
-				scale /= 2;
+				scale -= 0.1;
 				continue;
 			}
 

--- a/src/lib/spritesheets/TextureCompressor.js
+++ b/src/lib/spritesheets/TextureCompressor.js
@@ -33,13 +33,13 @@ export class SpritesheetCompressor {
 	 */
 	constructor(basis, ktx2FileCache) {
 		this.#basis = basis;
-		this.#ktx2FileCache = ktx2FileCache
+		this.#ktx2FileCache = ktx2FileCache;
 		const canvas = new OffscreenCanvas(0, 0);
 		const gl = canvas.getContext("webgl2");
 		this.#supportedCodecs = {
-			astc: !!gl.getExtension("WEBGL_compressed_texture_astc"),
-			bc7: !!gl.getExtension("EXT_texture_compression_bptc"),
-			dxt: !!gl.getExtension("WEBGL_compressed_texture_s3tc"),
+			astc: !!gl?.getExtension("WEBGL_compressed_texture_astc"),
+			bc7: !!gl?.getExtension("EXT_texture_compression_bptc"),
+			dxt: !!gl?.getExtension("WEBGL_compressed_texture_s3tc"),
 		};
 	}
 	/**

--- a/src/lib/spritesheets/ktx2FileCache.js
+++ b/src/lib/spritesheets/ktx2FileCache.js
@@ -4,7 +4,8 @@
 // cache version history:
 // 1: initial
 // 2: zstandard compressed ktx2 files and response metadata
-const cacheVersion = 2;
+// 3: Remove cache size limit and increase scaled spritesheet resolutions
+const cacheVersion = 3;
 const cacheName = `SequencerKTX2Cache-${cacheVersion}`;
 /** @type {Promise<Cache | null>} */
 let ktx2FileCache;
@@ -82,10 +83,6 @@ export class Ktx2FileCache {
 	 * @returns {Promise<void>}
 	 */
 	async saveKtxFileToCache(id, sourceHash, ktx2FileBuffer) {
-		// only cache files <= 30MB
-		if (ktx2FileBuffer.byteLength > 30 * 1000 * 1000) {
-			return;
-		}
 		const cacheStorage = await ktx2FileCache.catch(() => null);
 		if (!cacheStorage) {
 			return;
@@ -156,5 +153,5 @@ export class Ktx2FileCache {
 }
 
 /**
- * @typedef {{sprites: import("./FramePacker").SpriteData[], frameRate: number, scale: number}} CachedSpriteData
+ * @typedef {{sprites: import("./FramePacker.js").SpriteData[], frameRate: number, scale: number}} CachedSpriteData
  */


### PR DESCRIPTION
Some renaming for increased clarity.

The only real change in behavior is that spritesheets are now scaled in 10% increments (100%, 90%, 80%, ... down to the minimum size) instead of halved resolutions (100%, 50%, 25%, 12,5%, ...)

This also removes the file size limit, as even 8000x8000 px textures should be okay to fit in the cache after enabling zstandard compression. 

This also resets the spritesheet cache as 0.5x scale spritesheets are quite bad in most cases...