### PR TITLE
Fix loops when loopStart is undefined

### DIFF
--- a/src/canvas-effects/canvas-effect.js
+++ b/src/canvas-effects/canvas-effect.js
@@ -3267,7 +3267,9 @@ export default class CanvasEffect extends PIXI.Container {
 			return;
 		}
 
-		const restartTime = this._startTime || this._animationTimes.loopStart;
+		const restartTime = this._startTime === 0 && this._animationTimes.loopStart 
+		  ? this._animationTimes.loopStart 
+			: this._startTime;
 		// no loop delay means just start again at the beginning!
 		if (!this.loopDelay) {
 			this._currentLoops++;


### PR DESCRIPTION
`this._animationTimes.loopStart` can be undefined when `this._startTime` is 0...

Don't know what I was thinking when writing this :/ 

This now correctly does what I said previously: If `_startTime` is 0 (default) and a `this._animationTimes.loopStart` is defined, that value is used. Otherwise it falls back to `_startTime`.
