### PR TITLE
Various minor fixes

### DIFF
--- a/src/canvas-effects/canvas-effect.js
+++ b/src/canvas-effects/canvas-effect.js
@@ -1788,7 +1788,7 @@ export default class CanvasEffect extends PIXI.Container {
 
 		this.sprite.position.set(spriteOffsetX, spriteOffsetY);
 
-		this.sprite.anchor.set(
+		this.sprite.anchor?.set(
 			this.data.spriteAnchor?.x ?? 0.5,
 			this.data.spriteAnchor?.y ?? 0.5
 		);

--- a/src/canvas-effects/effects-layer.js
+++ b/src/canvas-effects/effects-layer.js
@@ -483,9 +483,12 @@ export class SequencerAboveUILayer {
 
   static removeContainerByEffect(inEffect) {
 		const layer = this.getLayer();
+		if (!(layer instanceof SequencerAboveUILayer)) return;
+
     const child = layer.children.find((child) => child === inEffect);
     if (!child) return;
     layer.removeChild(child);
+
     layer.renderable = layer.children.length > 0;
   }
 

--- a/src/canvas-effects/sequencer-sprite-manager.js
+++ b/src/canvas-effects/sequencer-sprite-manager.js
@@ -681,7 +681,7 @@ export class SequencerSpriteManager extends PIXI.Container {
 			this.managedSprite.destroy();
 		}
 		this.#managedSprite = view;
-		this.addChild(view);
+		this.addChildAt(view, 0);
 
 		return true;
 	}

--- a/src/canvas-effects/sequencer-sprite-manager.js
+++ b/src/canvas-effects/sequencer-sprite-manager.js
@@ -337,6 +337,11 @@ export class SequencerSpriteManager extends PIXI.Container {
 		return this.#managedSprite;
 	}
 
+	/** @return {PreciseText | null} */
+	get textSprite() {
+		return this.#textSprite
+	}
+
 	/**
 	 * caches current scaling values to be used for spritesheet scaling if needed
 	 */

--- a/src/lib/meshes/TilingSpriteMesh.js
+++ b/src/lib/meshes/TilingSpriteMesh.js
@@ -45,16 +45,15 @@ export default class TilingSpriteMesh extends SpriteMesh {
 	}
 
 	
-	get isVisionMaskEnabled() {
-		return this.shaderFlags.hasState('isVisionMaskEnabled')
+	get isVisionMaskingEnabled() {
+		return this.shaderFlags.hasState('isVisionMaskingEnabled')
 	}
 	/**
 	 * @param {boolean} value
 	 */
-	set isVisionMaskEnabled(value) {
-		this.shaderFlags.toggleState('isVisionMaskEnabled', value)
+	set isVisionMaskingEnabled(value) {
+		this.shaderFlags.toggleState('isVisionMaskingEnabled', value)
 	}
-
 
 	/**
 	 * @param {PIXI.ColorMatrixFilter | null} value

--- a/src/modules/sequencer-file-cache.js
+++ b/src/modules/sequencer-file-cache.js
@@ -204,8 +204,10 @@ const SequencerFileCache = {
       foundry.utils.getRoute(inSrc),
     ]
     await PIXI.Assets.unload(cacheKeys.filter((src) => !!src))
-    Object.values(sheet.textures).forEach((t) => t.destroy())
-    sheet.baseTexture.destroy()
+		if (sheet.textures) {
+			Object.values(sheet.textures).forEach((t) => t.destroy())
+		}
+    sheet.baseTexture?.destroy()
   },
 }
 


### PR DESCRIPTION
Discovered errors: Effects with only a text would not play because sprite.anchor was undefined and optional chaining was missing.

xRay setting was not working because the property for that setting was `isVisionMaskingEnabled`, but the setter was called `isVisionMaskEnabled`, leading to that flag never being set correctly.

Spritesheets under certain circumstances threw errors in the cleanup code. This had no effet other than console error messages being logged