### PR TITLE
Return early if sequencer layer is not active in mousemove handler

### DIFF
--- a/src/modules/sequencer-interaction-manager.js
+++ b/src/modules/sequencer-interaction-manager.js
@@ -70,9 +70,9 @@ export const InteractionManager = {
 
     window.addEventListener("mousemove", (event) => {
       if (!canvas.ready) return;
+      if (!this.isLayerActive) return;
       const hover = document.elementFromPoint(event.clientX, event.clientY);
       if (!hover || hover.id !== "board") return;
-      if (!this.isLayerActive) return;
       this._propagateEvent("mouseMove");
       if (this.state.LeftMouseDown && !this.startDragPosition) {
         this.startDragPosition = canvaslib.get_mouse_position();


### PR DESCRIPTION
This changes no functionality, simply omits the `document.elementFromPoint` call in case the sequencer layer is inactive.

I've not personally had any issues with performance with `document.elementFromPoint`, but I've seen the performance log of one case where each call to this function takes about 8ms. He is also using a high refresh monitor, so this function is called on each mouse move frame (independend of the canvas refresh cycle) every 6.1ms.
<img width="807" alt="Bildschirmfoto 2024-10-28 um 16 19 10" src="https://github.com/user-attachments/assets/74503fc7-75b9-4404-b97b-b9a96245ad27">