### PR TITLE
Hide visibility-bound effects for hidden tokens for non-gm users

### DIFF
--- a/src/canvas-effects/canvas-effect.js
+++ b/src/canvas-effects/canvas-effect.js
@@ -2107,6 +2107,7 @@ export default class CanvasEffect extends PIXI.Container {
 							(!attachedToTarget || (this.targetMesh?.occluded ?? true));
 						this.renderable =
 							baseRenderable &&
+							(!sourceHidden || game.user.isGM) &&
 							(sourceVisible || targetVisible) &&
 							this._checkWallCollisions();
 						this.alpha = sourceVisible && sourceHidden ? 0.5 : 1.0;


### PR DESCRIPTION
This extends the the visibility update logic to hide effects that are attached to tokens when the `bindVisibility` flag is active. No need to check for ownership of the token, as hidden tokens are invisible even to the owner.