### PR TITLE
Use calcualted framerate for spritesheet generation instead of metadata

### DIFF
--- a/src/lib/inspector-js/inspectorjs-js.d.ts
+++ b/src/lib/inspector-js/inspectorjs-js.d.ts
@@ -151,7 +151,6 @@ export declare class WebMTrack extends Track {
     private _frames;
     private _framesAlpha;
     private lastPts;
-    private nsPerFrame;
     private lastTimecodeBase;
     private timecodeScale;
     private codec;
@@ -161,6 +160,7 @@ export declare class WebMTrack extends Track {
     get framesAlpha(): Frame[];
     private static getType;
     private static getCodecNameFromID;
+    readonly nsPerFrame: number;
     getResolution(): [number, number];
     getFrames(): Frame[];
     getFramesAlpha(): Frame[];

--- a/src/lib/spritesheets/decodeWorker.js
+++ b/src/lib/spritesheets/decodeWorker.js
@@ -95,8 +95,13 @@ async function decodeWebm(buffer, minimumScale, id) {
 		if (!packedSheet) {
 			return errorResponse("Could not pack spritesheet");
 		}
+		const frameRate = !videoTrack.nsPerFrame || isNaN(videoTrack.nsPerFrame) ? metadata.frameRate : 1e9 / videoTrack.nsPerFrame
 
-		ktx2FileCache.saveSpritesToCache(id, sourceHash, { sprites: packedSheet.sprites, frameRate: metadata.frameRate, scale: packedSheet.scale });
+		if (!frameRate) {
+			return errorResponse("Could not get frameRate for video file");
+		}
+
+		ktx2FileCache.saveSpritesToCache(id, sourceHash, { sprites: packedSheet.sprites, frameRate, scale: packedSheet.scale });
 		
 		compressedSheet = await compressor.getCompressedRessourceInfo(
 			packedSheet.imageBuffer,
@@ -110,7 +115,7 @@ async function decodeWebm(buffer, minimumScale, id) {
 			return errorResponse("Could not encode spritesheet to compressed texture");
 		}
 		
-		sheet = { ...compressedSheet, sprites: packedSheet.sprites, fps: metadata.frameRate, scale: packedSheet.scale };
+		sheet = { ...compressedSheet, sprites: packedSheet.sprites, fps: frameRate, scale: packedSheet.scale };
 	}
 
 	return {


### PR DESCRIPTION
This PR aims to improve the frameRate calculation of spritesheets, using the (technically required) frame timing information in the video track instead of metadata to calculate the frameRate. It falls back to the metadata if the timing is not available (variable frameRate is a thing, but not even many players support this, no idea if web browsers do. I couldn't find a video file with actual variable frame timing)

If no frameRate can be found, spritesheet generation now bails and the video file will continue to be used for the effect.

Additionally, if an existing effect is found in the cache without frameRate timing, the cache entry is now deleted, nothing returned and the spritesheet will be calculated anew.