### PR TITLE
Fix calculation of dimensions for canvas tiles

### DIFF
--- a/src/lib/canvas-lib.js
+++ b/src/lib/canvas-lib.js
@@ -242,6 +242,7 @@ export function get_object_dimensions(inObj, half = false) {
     inObj?.w ??
     inObj?.shape?.width ??
     (inObj?.shape?.radius ? inObj?.shape?.radius * 2 : undefined) ??
+    inObj?.bounds?.width ??
     inObj?.width ??
     canvas.grid.size;
 
@@ -250,6 +251,7 @@ export function get_object_dimensions(inObj, half = false) {
     inObj?.h ??
     inObj?.shape?.height ??
     (inObj?.shape?.radius ? inObj?.shape?.radius * 2 : undefined) ??
+    inObj?.bounds?.height ??
     inObj?.height ??
     canvas.grid.size;
 


### PR DESCRIPTION
Reason for this PR is that effects being attached to tiles and having `scaleToObject` set were apparently not being rendered. Underlying reason for that is that the Tile object `width` and `height` values are 0 when not also displaying the token border. This is most likely a Foundry V12 change that went unnoticed.

As a fix, we can query the tiles bounds instead. I made sure that this produces the correcdt results for tiles, tokens, templates, plain coordinates and crosshairs.

I also verified that shapes and screen space (above) ui is not broken :)