### PR TITLE
Crosshairs: add grid-snapping resolution to API

### DIFF
--- a/docs/crosshair.md
+++ b/docs/crosshair.md
@@ -26,6 +26,7 @@ crosshair = {
 	},
 	snap: {
 		position: number, // See CONST.GRID_SNAPPING_MODES
+		resolution: number, // How many sub-squares the snapping should consider (default: 1)
 		size: number, // See CONST.GRID_SNAPPING_MODES
 		direction: mumber // How many degrees the direction of this crosshair should snap at
 	},

--- a/src/modules/sequencer-crosshair/CrosshairsPlaceable.js
+++ b/src/modules/sequencer-crosshair/CrosshairsPlaceable.js
@@ -188,8 +188,8 @@ export default class CrosshairsPlaceable extends MeasuredTemplate {
 		});
 	}
 
-	#getSnappedPoint(point, mode = this.crosshair.snap.position) {
-		return canvas.grid.getSnappedPoint(point, { mode, resolution: 1 });
+	#getSnappedPoint(point, mode = this.crosshair.snap.position, resolution = this.crosshair.snap.resolution) {
+		return canvas.grid.getSnappedPoint(point, { mode, resolution: resolution ?? 1 });
 	}
 
 	#onMove(evt) {


### PR DESCRIPTION
Separately, do you know what the `size` snapping property actually does? I can't seem to find it referenced in the code, and the documentation is a bit unclear...

Thanks! 😁