### PR TITLE
Fix alpha banding issues in scaled spritesheet

### DIFF
--- a/src/lib/spritesheets/SpritesheetGenerator.js
+++ b/src/lib/spritesheets/SpritesheetGenerator.js
@@ -149,13 +149,13 @@ export class SpritesheetGenerator {
 		});
 		const texture = new PIXI.BaseTexture(resource, {
 			alphaMode: PIXI.ALPHA_MODES.PREMULTIPLIED_ALPHA,
-			mipmap: PIXI.MIPMAP_MODES.ON_MANUAL,
+			mipmap: PIXI.MIPMAP_MODES.OFF,
 			scaleMode: PIXI.SCALE_MODES.LINEAR,
 			width: firstLevel.width,
 			height: firstLevel.height,
 			wrapMode: PIXI.WRAP_MODES.CLAMP,
 			format: PIXI.FORMATS.RGBA,
-			type: PIXI.TYPES.UNSIGNED_INT,
+			type: PIXI.TYPES.UNSIGNED_BYTE,
 			target: PIXI.TARGETS.TEXTURE_2D,
 			pixiIdPrefix: id,
 		});

--- a/src/lib/spritesheets/TextureCompressor.js
+++ b/src/lib/spritesheets/TextureCompressor.js
@@ -54,7 +54,7 @@ export class SpritesheetCompressor {
 		encoder.setPerceptual(true);
 		encoder.setUASTC(true);
 		encoder.setCheckForAlpha(true);
-		encoder.setMipGen(true);
+		encoder.setMipGen(false);
 		encoder.setMipSRGB(true);
 		encoder.setDebug(false);
 		return encoder;

--- a/src/lib/spritesheets/ktx2FileCache.js
+++ b/src/lib/spritesheets/ktx2FileCache.js
@@ -4,7 +4,8 @@
 // 1: initial
 // 2: zstandard compressed ktx2 files and response metadata
 // 3: Remove cache size limit and increase scaled spritesheet resolutions
-const cacheVersion = 3;
+// 4: Fix alpha banding issues for scaled spritesheets.
+const cacheVersion = 4;
 const cacheName = `SequencerKTX2Cache-${cacheVersion}`;
 /** @type {Promise<Cache | null>} */
 let ktx2FileCache;


### PR DESCRIPTION
Woha, that was a fun one to debug..

Quick recap, this is how the white cloud jb2a effect is supposed to look like:
![image](https://github.com/user-attachments/assets/69979391-aba2-48cd-ac28-54b5bd41b8a6)

Whereas this is the result after spritesheet compilation:
![image](https://github.com/user-attachments/assets/6f0a7dbb-1a45-4f59-8428-4b5255e0b261)
(notice the fringing at the edges)

While there also seem to be some issues with premultiplied alpha, this PR is about the fringes or alpha banding.

In my testing, this error should appear for everyone using chromium based browsers (and probably firefox,safari, ...) for spritesheets that have to be scaled to fit into a texture, which includes many larger and/or longer animations, for example `jb2a.fog_cloud.01.white` as in this example.

A quick note about premultiplied alpha and why we need it: EVERY texture is supposed to be in premultiplied alpha form. For most image files, this happens implicitly when loading the image in a canvas context or somewhat explicitly by pixi.js when uploading to the GPU. Shaders generally speaking always need premultiplied alpha textures.

The issue with our spritesheets is that we use GPU-compressed textures which cannot be converted on the fly. This means we have to do the premultiplication ourself.

The issue was in the order we did it. Previously:
1. Extract rgb and alpha frames from video
2. combine alpha and rgb into a single rgba frame + premultiply alpha
3. Optionally scale frames to fit into 8k x 8k texture
4. combine everything into one texture

The issue was with step 3, as scaling these frames is done with thelp of the canvas API... which ALSO premultiplies the alpha before scaling and then converts it back when giving us the scaled image buffer. Because color values are discrete 8 bit values, this conversion process can be lossy (if imperceptible) for regular images. For premultiplied alpha images, this process can be devastating.

Example for a png image (non-premultiplied alpha)
color values: `[9, 20, 80, 25]` (about 0.098 alpha in floating point)
premulitplied: `[1, 2, 8]`
and back to normal: `[10, 20, 82, 25]`, not perfect, but not too bad

However, if we already have premultiplied alpha for low alpha values this leads to terrible banding:

premultiplied color values: `[1, 2, 8, 25]` (about 0.098 alpha in floating point)
premultiply again: `[0, 0, 1, 25]`
and back to premultiplied: `[0, 0, 8, 25]` 
and to normal: `[0, 0, 82, 25]`   which is not good at all


Luckily for us we can simply move our premultiplication step to number 4, which is what this PR does.

I have also changed the previously used Uint8Array for color data to a Uint8ClampedArray, as that automatically rounds instead of floors color values. This should reduce artifacting even more for small color or alpha values.

Lastly after some more testing I have disabled mipmap generation as this does not seem to have really any real benefit for a 2d applicationbut uses about 30% more time to compute and space to store the texture.