### PR TITLE
Wait for canvas ready before trying to initialize persistent effects

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -92,7 +92,7 @@ const setupModule = foundry.utils.debounce(() => {
     Hooks.callAll("sequencer.ready");
     Hooks.callAll("sequencerReady");
   }
-  if (!canvasReady) {
+  if (!canvasReady && game.canvas?.ready) {
     canvasReady = true;
     SequencerEffectManager.initializePersistentEffects();
   }


### PR DESCRIPTION
In certain cases, one of the hooks calling `setupModule` can execute before the canvas is actually ready, leading to persisted animations not being correctly initialized.

This PR simply adds another check for the foundry canvas ready flag before trying to initialize the persisted effects to catch this edgecase.