### PR TITLE
Fix right click drag, when mouse up happens after holding cursor still

### DIFF
--- a/src/modules/sequencer-crosshair/CrosshairsPlaceable.js
+++ b/src/modules/sequencer-crosshair/CrosshairsPlaceable.js
@@ -199,7 +199,7 @@ export default class CrosshairsPlaceable extends MeasuredTemplate {
 		const leftDown = (evt.buttons & 1) > 0;
 		const rightDown = (evt.buttons & 2) > 0;
 		this.#isDrag = !!(leftDown && canvas.mouseInteractionManager.isDragging);
-		this.#isPanning = !!(rightDown && canvas.mouseInteractionManager.isDragging);
+		this.#isPanning = this.#isPanning || !!(rightDown && canvas.mouseInteractionManager.isDragging);
 
 		if (this.#isPanning) return;
 


### PR DESCRIPTION
Foundry, by default, allows you to pan the map with a right click drag. Sequencer also allows this when using Crosshairs. But sometimes right click dragging with a sequence will cancel it, and sometimes it pans and doesn't cancel (as expected).

The reason it sometimes cancels, is if the user stops moving the cursor beforehand, then panning gets turned off. So when the user releases the right mouse button, since `this.#isPanning` is now false which makes releasing the button cancel the crosshairs instead of ending the panning.

This change makes it so that once a pan is started, it essentially is always a pan, and can't be "reverted" back to a non-panning-click like what happens now.

note: I also tried this with `this.#isDrag` just above but I didn't see any difference in behavior one way or the other so I opted not to change it.