### PR TITLE
fix: use this.data.rotateTowards instead of this.rotateTowards

### DIFF
--- a/src/canvas-effects/canvas-effect.js
+++ b/src/canvas-effects/canvas-effect.js
@@ -1602,7 +1602,7 @@ export default class CanvasEffect extends PIXI.Container {
 		}
 
 		// rotateTowards
-		if (this.rotateTowards && this.data.rotateTowards?.attachTo) {
+		if (this.data.rotateTowards && this.data.rotateTowards?.attachTo) {
 			this._addToTicker(this._transformRotateTowardsAttachedSprite);
 		}
 


### PR DESCRIPTION
Previously the check used `this.rotateTowards`, which was undefined.
This caused rotateTowards with attachTo to never trigger.  
Fixed to check `this.data.rotateTowards` instead.