### PR TITLE
feat(copy-sprite-dyn) Add Support for Dynamic Tokens for Copy Sprite

### DIFF
--- a/src/sections/effect.js
+++ b/src/sections/effect.js
@@ -2178,7 +2178,9 @@ export default class EffectSection extends Section {
 		this._mirrorY = this._mirrorY || (this._randomMirrorY && Math.random() < 0.5)
 
 		if (this._copySprite) {
-			this._file = this._file || this._copySprite.object?.texture?.src;
+			this._file = this._file || this._copySprite.object?.ring?.enabled ?
+				this._copySprite.object?.ring?.subject?.texture || this._copySprite.object?.texture?.src :
+				this._copySprite.object?.texture?.src;
 
 			if (this._source === null) {
 				this._source = this._validateLocation(this._copySprite.object);


### PR DESCRIPTION
closes [FEAT] - Add Support for Dynamic Tokens `.copySprite()` #406