### PR TITLE
Fixed tile centering logic in get_object_position

### DIFF
--- a/src/lib/canvas-lib.js
+++ b/src/lib/canvas-lib.js
@@ -196,6 +196,11 @@ export function get_object_position(
       x: obj.document.x,
       y: obj.document.y,
     };
+
+    if (!exact) {
+      pos.x += Math.abs(obj.document.width / 2);
+      pos.y += Math.abs(obj.document.height / 2);
+    }
   } else if (obj instanceof foundry.canvas.placeables.Token) {
     const halfSize = get_object_dimensions(obj, true);
     pos = {


### PR DESCRIPTION
Error: .atLocation(tile) positioned tile graphics at the top-left instead of centering them.

Cause: Deletion of the centering offset calculation block during v12 cleanup / FoundryShim removal.

Fix: Added back the logic to adjust the position by half of the tile's document width and height when exact is false.