### PR TITLE
Store journal flag database instead of `getName`ing each time

### DIFF
--- a/src/utils/flag-manager.js
+++ b/src/utils/flag-manager.js
@@ -7,9 +7,10 @@ const flagManager = {
 	flagAddBuffer: new Map(),
 	flagRemoveBuffer: new Map(),
 	_latestFlagVersion: false,
+	_database: null,
 
 	get database(){
-		return game.journal.getName(CONSTANTS.DATABASE_NAME);
+		return this._database ??= game.journal.getName(CONSTANTS.DATABASE_NAME);
 	},
 
 	setup() {


### PR DESCRIPTION
Howdy. Minor optimization here - except for when it isn't. I was trying to troubleshoot why an Aura Effect user's world ground to a halt upon removal of an Aura of Protection effect, and it's because there was an Automated Animations autorec matching "Protection" which was, therefore, removed when the token went out of range, so Sequencer calls its `SequencerEffectManager.objectDeleted`, which in turn iterates over all documents on all non-viewed scenes, gets their effect flags, and ends the effects as necessary.

In a normal world, this is probably no issue. This user had 453 scenes in their world, with a total of 48,237 placeables on said scenes. So, 48,237 times (minus the number of objects on the viewed scene, I suppose) the flag manager's `getEffectFlags` was being called, and in turn `getDatabaseFlags`, which in turn calls `_getDatabaseData` twice (one for `effects`, once for `sounds`). So we're looking at roughly 95,000 of those calls, each of which accesses the `database` getter, which calls `game.journal.getName(CONSTANTS.DATABASE_NAME)`. This user also happened to have 1966 journals. _So_, 95,000ish searches in a collection of size 1966. 

My change is to cache the database the first time the getter is accessed, and return it in future accesses. Again, I have to imagine in the majority of worlds this won't make any tangible difference. In this world, though, it reduced the sum duration of the effect removal from ~4200ms to ~450ms. Which still isn't _great_, but there's really only so much one can hope to do with such a bloated world.